### PR TITLE
fix: correct BLOCK_PATTERNS regex split for entries containing colon (#23)

### DIFF
--- a/hooks/secret-scanner.sh
+++ b/hooks/secret-scanner.sh
@@ -71,8 +71,10 @@ BLOCK_PATTERNS=(
   'client_secret\s*=\s*["\x27][A-Za-z0-9_\-]{10,}["\x27]:Hardcoded client secret'
 )
 
+# Convention: DESC must not contain a colon — splitter uses last-colon delimiter
+# so regexes containing colons (URI schemes, header names) reconstruct correctly.
 for ENTRY in "${BLOCK_PATTERNS[@]}"; do
-  PATTERN="${ENTRY%%:*}"
+  PATTERN="${ENTRY%:*}"
   DESC="${ENTRY##*:}"
 
   if echo "$CONTENT" | grep -qE -- "$PATTERN"; then
@@ -98,7 +100,7 @@ WARN_PATTERNS=(
 PII_WARNED=false
 
 for ENTRY in "${WARN_PATTERNS[@]}"; do
-  PATTERN="${ENTRY%%:*}"
+  PATTERN="${ENTRY%:*}"
   DESC="${ENTRY##*:}"
 
   if echo "$CONTENT" | grep -qE -- "$PATTERN"; then

--- a/tests/test-secret-scanner.sh
+++ b/tests/test-secret-scanner.sh
@@ -98,6 +98,13 @@ assert_allowed "Short string" "x = 42"
 assert_allowed "Comment with sk-" "# sk- prefix is used for API keys"
 assert_allowed "Empty-ish content" "const x = true"
 
+# Regression for #23 — bare keywords in prose must not be blocked.
+# Before fix, BLOCK_PATTERNS split on first ':' degraded the auth and DB
+# regexes to their bare keyword prefixes, blocking documentation that merely
+# mentioned the words. After fix, only the full payload forms match.
+assert_allowed "Auth keyword in prose" "# Doc mentions the Authorization header"
+assert_allowed "DB keyword in prose"   "We use mongodb as our document store."
+
 # ============================================================
 # Edge cases
 # ============================================================


### PR DESCRIPTION
## Summary

Fixes #23 — `${ENTRY%%:*}` (longest-suffix removal) cut at the FIRST colon, degrading two pattern regexes to their bare keyword prefixes at runtime:

- `mongodb(\+srv)?://[^\s]+` → `mongodb(\+srv)?`
- `Authorization:\s*Bearer\s+[A-Za-z0-9_\-\.]{20,}` → `Authorization`

This blocked any prose that merely mentioned the bare keywords (docs, runbooks, README files, comments) when written via `Edit`/`Write`/`MultiEdit`. The maintainer hit this himself authoring an internal NetBird API runbook (2026-04-28).

The fix is a one-character change per occurrence: `%%:*` → `%:*` (shortest-suffix removal — cuts at the LAST colon). Single-colon entries are unaffected, so the existing 25 BLOCK + 3 WARN patterns continue to match exactly as before.

## Changes

- `hooks/secret-scanner.sh` — replace `${ENTRY%%:*}` with `${ENTRY%:*}` at both BLOCK and WARN loop sites; add convention comment noting descriptions must not contain `:`
- `tests/test-secret-scanner.sh` — add 2 regression tests in the ALLOW section (`Auth keyword in prose`, `DB keyword in prose`)

## Test plan

- [x] `bash tests/test-secret-scanner.sh` → **36/36 PASS** (was 34/34, +2 regression tests)
- [x] `bash tests/validate-plugin.sh --skip-install-check` → **53/53 PASS** (no structural regression)
- [x] **RED-GREEN proof**: locally reverted scanner via `sed 's/${ENTRY%:\*}/${ENTRY%%:*}/g'`, ran tests → exactly the 2 new asserts FAIL on the broken version, then restore + re-run → 36/36 PASS
- [x] Manual positive proof: `Write` payload containing only the bare keyword `Authorization` (no colon, no bearer payload) → `exit=0` (was `exit=2` before fix)
- [x] Manual negative proof: `Write` payload containing the full header form (`Authorization: Bearer <≥20-char token>`) → `exit=2` (real secrets still blocked)

## Out of scope

- README scanner-test-count update (`34 tests` → `36 tests` at line 363) — local Markdown formatter rewrites all tables on every edit, producing 140 lines of unrelated noise. Will land in a separate doc-only PR.
- `MEMORY.md` (auto-memory) bullet was updated locally to `36 tests` — not in this PR.

Refs #23