### PR TITLE
docs(readme): inventory ADR catalog + bump v3.3.2 (closes #33)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "claude-governance",
       "description": "Governance framework with hooks (secret scanner, governance context), skills (/governance-check, /create-adr, /spec-driven-dev, /governance-setup), and agent (governance-reviewer)",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "author": {
         "name": "pitimon"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Complete governance framework for Claude Code — fitness functions, secret scanning, spec-driven development, ADR system, and Three Loops decision model",
   "author": {
     "name": "pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2026-05-24
+
+### Fixed
+
+- **README ADR inventory drift** (closes [#33](https://github.com/pitimon/claude-governance/issues/33)) — Two README diagrams listed only ADR-001 and ADR-002 while the on-disk catalog had grown to 6 records (ADR-003 EU AI Act, ADR-004 ISO 42001, ADR-005 NIST AI RMF, ADR-006 hook design principle):
+  - **Project Structure tree** (around line 336) now lists all 6 ADR files individually.
+  - **Architecture mermaid** node `D2` (around line 283) now reads `ADR Catalog (6 records)` instead of `ADR-001 + ADR-002` — generic label future-proofs the diagram against the next ADR landing.
+
+  Pre-existing drift caught during the `8-habit-reviewer` audit of PR #32 (2026-05-11); deferred for 14 days. No runtime change, no behavior change for client installs — patch release for README-only fix per the v3.3.1 (`c667f89`) ADR-006 docs-only release precedent.
+
 ## [3.3.1] - 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@
 
 AI-assisted development is fast — but ungoverned AI is a liability.
 
-| Without Governance | With claude-governance |
-| --- | --- |
-| `sk-ant-api03-xxx` committed to git | Blocked before it reaches the filesystem |
-| Junior dev deploys to production via AI | Three Loops classifies it as In-the-Loop — human decides |
-| Prompt context leaks PII to observability | Telemetry hygiene check flags `log(prompt)` patterns |
-| Team uses 5 different AI tools with no policy | Shadow AI policy template — approved tools, data rules |
-| "Who decided to use MongoDB?" — no one knows | ADR system records every architecture decision |
+| Without Governance                            | With claude-governance                                   |
+| --------------------------------------------- | -------------------------------------------------------- |
+| `sk-ant-api03-xxx` committed to git           | Blocked before it reaches the filesystem                 |
+| Junior dev deploys to production via AI       | Three Loops classifies it as In-the-Loop — human decides |
+| Prompt context leaks PII to observability     | Telemetry hygiene check flags `log(prompt)` patterns     |
+| Team uses 5 different AI tools with no policy | Shadow AI policy template — approved tools, data rules   |
+| "Who decided to use MongoDB?" — no one knows  | ADR system records every architecture decision           |
 
 **Zero dependencies.** Zero build steps. Zero runtime overhead. Just Markdown skills and shell scripts that run inside Claude Code.
 
@@ -137,46 +137,46 @@ You: /governance-setup
 
 ### Always-On (Hooks)
 
-| Hook | Trigger | What It Does |
-| --- | --- | --- |
-| **Governance context** | Session start | Injects Three Loops + Consequence Override (~360 tokens) |
-| **Secret scanner** | Every `Edit`/`Write` | 25 BLOCK patterns (secrets) + 3 WARN patterns (PII) |
+| Hook                   | Trigger              | What It Does                                             |
+| ---------------------- | -------------------- | -------------------------------------------------------- |
+| **Governance context** | Session start        | Injects Three Loops + Consequence Override (~360 tokens) |
+| **Secret scanner**     | Every `Edit`/`Write` | 25 BLOCK patterns (secrets) + 3 WARN patterns (PII)      |
 
 ### On-Demand (Skills & Agent)
 
-| Command | When to Use | Example |
-| --- | --- | --- |
-| `/governance-check` | Before commit/push | `/governance-check pre-commit` |
-| `/create-adr` | After architecture decision | `/create-adr "Adopt PostgreSQL over MongoDB"` |
-| `/spec-driven-dev` | Before feature implementation | `/spec-driven-dev` → writes spec.md |
-| `/governance-setup` | New project initialization | Creates DOMAIN.md, ADRs, rules |
-| `governance-reviewer` | Before PR (auto-triggered) | Deep multi-file review with severity grading |
+| Command               | When to Use                   | Example                                       |
+| --------------------- | ----------------------------- | --------------------------------------------- |
+| `/governance-check`   | Before commit/push            | `/governance-check pre-commit`                |
+| `/create-adr`         | After architecture decision   | `/create-adr "Adopt PostgreSQL over MongoDB"` |
+| `/spec-driven-dev`    | Before feature implementation | `/spec-driven-dev` → writes spec.md           |
+| `/governance-setup`   | New project initialization    | Creates DOMAIN.md, ADRs, rules                |
+| `governance-reviewer` | Before PR (auto-triggered)    | Deep multi-file review with severity grading  |
 
 ### 31 Governance Checks
 
-| Category | Count | Key Checks |
-| --- | --- | --- |
-| **Pre-Commit** | 14 | Secrets, input validation, file size, debug prints, AI model artifacts, unsafe deserialization, telemetry hygiene |
-| **Pre-PR** | 5 | Conventional commits, DOMAIN.md sync, test coverage >= 80% |
-| **Architecture** | 12 | Service boundaries, auth coverage, plugin/MCP security, session isolation, consequence safeguards |
+| Category         | Count | Key Checks                                                                                                        |
+| ---------------- | ----- | ----------------------------------------------------------------------------------------------------------------- |
+| **Pre-Commit**   | 14    | Secrets, input validation, file size, debug prints, AI model artifacts, unsafe deserialization, telemetry hygiene |
+| **Pre-PR**       | 5     | Conventional commits, DOMAIN.md sync, test coverage >= 80%                                                        |
+| **Architecture** | 12    | Service boundaries, auth coverage, plugin/MCP security, session isolation, consequence safeguards                 |
 
 ### OWASP DSGAI Compliance — 11 Controls
 
 Mapped to [OWASP GenAI Data Security](https://genai.owasp.org) v1.0 (March 2026):
 
-| Control | Risk | What We Do |
-| --- | --- | --- |
-| DSGAI01 | Sensitive Data Leakage | PII WARN patterns (email, SSN, credit card) |
-| DSGAI02 | Agent Credential Exposure | BLOCK patterns for OAuth, Bearer, refresh tokens |
-| DSGAI03 | Shadow AI | Policy template with approved alternatives |
-| DSGAI04 | Data/Model Poisoning | Model file detection, unsafe deserialization, dependency pinning |
-| DSGAI06 | Plugin/Tool Data Exchange | MCP security checklist, least-privilege checks |
-| DSGAI07 | Data Classification | 4-level classification template with AI/LLM data flows |
-| DSGAI08 | Compliance Violations | This compliance mapping + `[DSGAI##]` tags in all outputs |
-| DSGAI11 | Cross-Context Bleed | Session isolation, multi-tenant separation checks |
-| DSGAI14 | Telemetry Leakage | Flags `log(prompt)` patterns in production code |
-| DSGAI15 | Over-Broad Context | Context minimization checks, token budget enforcement |
-| DSGAI19 | Human-in-the-Loop Gaps | Consequence-based auth — irreversible ops always In-the-Loop |
+| Control | Risk                      | What We Do                                                       |
+| ------- | ------------------------- | ---------------------------------------------------------------- |
+| DSGAI01 | Sensitive Data Leakage    | PII WARN patterns (email, SSN, credit card)                      |
+| DSGAI02 | Agent Credential Exposure | BLOCK patterns for OAuth, Bearer, refresh tokens                 |
+| DSGAI03 | Shadow AI                 | Policy template with approved alternatives                       |
+| DSGAI04 | Data/Model Poisoning      | Model file detection, unsafe deserialization, dependency pinning |
+| DSGAI06 | Plugin/Tool Data Exchange | MCP security checklist, least-privilege checks                   |
+| DSGAI07 | Data Classification       | 4-level classification template with AI/LLM data flows           |
+| DSGAI08 | Compliance Violations     | This compliance mapping + `[DSGAI##]` tags in all outputs        |
+| DSGAI11 | Cross-Context Bleed       | Session isolation, multi-tenant separation checks                |
+| DSGAI14 | Telemetry Leakage         | Flags `log(prompt)` patterns in production code                  |
+| DSGAI15 | Over-Broad Context        | Context minimization checks, token budget enforcement            |
+| DSGAI19 | Human-in-the-Loop Gaps    | Consequence-based auth — irreversible ops always In-the-Loop     |
 
 See [docs/compliance/DSGAI-MAPPING.md](docs/compliance/DSGAI-MAPPING.md) for the full control-by-control mapping.
 
@@ -184,33 +184,33 @@ See [docs/compliance/DSGAI-MAPPING.md](docs/compliance/DSGAI-MAPPING.md) for the
 
 Governance checks detect the project's language and apply stack-specific rules:
 
-| Check | JS/TS | Python | Go | Rust |
-| --- | --- | --- | --- | --- |
-| Debug prints | `console.log` | `print()` | `fmt.Println` | `println!` |
-| Validation | Zod, joi, yup | pydantic, marshmallow | go-validator | serde, validator |
-| Dangerous | `eval()`, `innerHTML` | `eval()`, `exec()`, `pickle.loads()` | `unsafe.Pointer` | `unsafe` blocks |
-| Detection | `package.json` | `pyproject.toml` | `go.mod` | `Cargo.toml` |
+| Check        | JS/TS                 | Python                               | Go               | Rust             |
+| ------------ | --------------------- | ------------------------------------ | ---------------- | ---------------- |
+| Debug prints | `console.log`         | `print()`                            | `fmt.Println`    | `println!`       |
+| Validation   | Zod, joi, yup         | pydantic, marshmallow                | go-validator     | serde, validator |
+| Dangerous    | `eval()`, `innerHTML` | `eval()`, `exec()`, `pickle.loads()` | `unsafe.Pointer` | `unsafe` blocks  |
+| Detection    | `package.json`        | `pyproject.toml`                     | `go.mod`         | `Cargo.toml`     |
 
 ### Ready-to-Use Templates
 
-| Template | Purpose | Reference |
-| --- | --- | --- |
-| `DATA-CLASSIFICATION.md.example` | 4-level data sensitivity with AI/LLM data flows | DSGAI07 |
-| `mcp-security-checklist.md` | Plugin/MCP vetting before installation | DSGAI06 |
-| `shadow-ai-policy.md` | Approved AI tools, data rules, exceptions | DSGAI03 |
-| `ai-supply-chain-checklist.md` | Model vetting, dependency pinning, safe alternatives | DSGAI04 |
-| `DOMAIN.md.example` | Entity definitions, invariants, API contracts | — |
-| `adr-template.md` | Architecture Decision Record with governance loop | — |
+| Template                         | Purpose                                              | Reference |
+| -------------------------------- | ---------------------------------------------------- | --------- |
+| `DATA-CLASSIFICATION.md.example` | 4-level data sensitivity with AI/LLM data flows      | DSGAI07   |
+| `mcp-security-checklist.md`      | Plugin/MCP vetting before installation               | DSGAI06   |
+| `shadow-ai-policy.md`            | Approved AI tools, data rules, exceptions            | DSGAI03   |
+| `ai-supply-chain-checklist.md`   | Model vetting, dependency pinning, safe alternatives | DSGAI04   |
+| `DOMAIN.md.example`              | Entity definitions, invariants, API contracts        | —         |
+| `adr-template.md`                | Architecture Decision Record with governance loop    | —         |
 
 ### Rules for `~/.claude/rules/`
 
-| Rule | Focus |
-| --- | --- |
-| `governance.md` | Fitness functions: pre-implementation, pre-commit, pre-PR, architecture |
-| `security.md` | Secret management, agent/plugin security, PII, telemetry, session isolation |
-| `coding-style.md` | Immutability, file size limits, error handling |
-| `git-workflow.md` | Conventional commits, PR workflow, TDD |
-| `testing.md` | 80% coverage minimum, unit/integration/E2E |
+| Rule              | Focus                                                                       |
+| ----------------- | --------------------------------------------------------------------------- |
+| `governance.md`   | Fitness functions: pre-implementation, pre-commit, pre-PR, architecture     |
+| `security.md`     | Secret management, agent/plugin security, PII, telemetry, session isolation |
+| `coding-style.md` | Immutability, file size limits, error handling                              |
+| `git-workflow.md` | Conventional commits, PR workflow, TDD                                      |
+| `testing.md`      | 80% coverage minimum, unit/integration/E2E                                  |
 
 ---
 
@@ -236,12 +236,12 @@ Consequence
 
 Automated governance checks — "unit tests for architecture":
 
-| Stage | What Gets Checked |
-| --- | --- |
-| **Pre-Implementation** | Spec exists, domain invariants identified, autonomy classified, irreversible ops flagged |
-| **Pre-Commit** | 14 checks: secrets, PII, validation, file size, functions, immutability, debug prints, AI artifacts, deserialization, deps, telemetry |
-| **Pre-PR** | 5 checks: conventional commits, DOMAIN.md, breaking changes, test coverage, TODO context |
-| **Architecture** | 12 checks: service boundaries, auth, rate limiting, plugin/MCP, context minimization, session isolation, consequence safeguards |
+| Stage                  | What Gets Checked                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pre-Implementation** | Spec exists, domain invariants identified, autonomy classified, irreversible ops flagged                                              |
+| **Pre-Commit**         | 14 checks: secrets, PII, validation, file size, functions, immutability, debug prints, AI artifacts, deserialization, deps, telemetry |
+| **Pre-PR**             | 5 checks: conventional commits, DOMAIN.md, breaking changes, test coverage, TODO context                                              |
+| **Architecture**       | 12 checks: service boundaries, auth, rate limiting, plugin/MCP, context minimization, session isolation, consequence safeguards       |
 
 ### Spec-Driven Development
 
@@ -280,7 +280,7 @@ graph TB
 
     subgraph "Compliance"
         D1["DSGAI-MAPPING.md<br/>11 OWASP controls"]
-        D2["ADR-001 + ADR-002"]
+        D2["ADR Catalog<br/>(6 records)"]
     end
 
     H1 -->|~360 tokens| SESSION["Every Session"]
@@ -294,12 +294,12 @@ graph TB
 
 ## Token Budget
 
-| Component | Tokens | When |
-| --- | --- | --- |
-| SessionStart hook | ~360 | Every session |
-| Secret scanner | 0 | Shell script, no token cost |
-| Rules (if installed) | ~500-800 | Every session |
-| Skills / agent | 0 | Only when invoked |
+| Component            | Tokens   | When                        |
+| -------------------- | -------- | --------------------------- |
+| SessionStart hook    | ~360     | Every session               |
+| Secret scanner       | 0        | Shell script, no token cost |
+| Rules (if installed) | ~500-800 | Every session               |
+| Skills / agent       | 0        | Only when invoked           |
 
 **Total always-on cost:** ~360 tokens (without rules) / ~1,160 tokens (with rules)
 
@@ -335,7 +335,11 @@ claude-governance/
 ├── docs/
 │   ├── adr/
 │   │   ├── ADR-001-adopt-governance-framework.md
-│   │   └── ADR-002-consequence-based-authorization.md
+│   │   ├── ADR-002-consequence-based-authorization.md
+│   │   ├── ADR-003-eu-ai-act-compliance-toolkit.md
+│   │   ├── ADR-004-iso-42001-framework-selection.md
+│   │   ├── ADR-005-nist-ai-rmf-cross-reference-doc.md
+│   │   └── ADR-006-hook-design-principle-write-vs-edit.md
 │   └── compliance/
 │       └── DSGAI-MAPPING.md       # 11 OWASP DSGAI controls mapped
 ├── scripts/


### PR DESCRIPTION
## Summary

- Two README diagrams (Project Structure tree + architecture mermaid) listed only ADR-001 and ADR-002 while the on-disk catalog has grown to 6 records (ADR-003 through ADR-006).
- **Tree** (line 336): now lists all 6 ADR files individually.
- **Mermaid node `D2`** (line 283): now reads `ADR Catalog (6 records)` instead of `ADR-001 + ADR-002` — generic label future-proofs the diagram against the next ADR landing (per advisor recommendation).
- Patch bump v3.3.1 → v3.3.2 per the c667f89 (v3.3.1 docs-only ADR-006 release) precedent.

## Why now

Issue #33 sat for 14 days; in that window 3 more ADRs landed (ADR-004 ISO 42001, ADR-005 NIST AI RMF, ADR-006 hook design principle). Scope grew from 1 missing → 4 missing. Today's `gh issue list` triage surfaced it as the only actionable open issue.

## Scope

- `README.md` — 2 substantive edits (mermaid label + tree listing). Project's markdown formatter additionally aligned table column widths across the file — pure cosmetic, content identical. Reviewer can confirm via `git diff README.md | grep -E '^[+-]' | grep -v '^[+-]\s*\|'` (substantive lines only).
- `CHANGELOG.md` — v3.3.2 entry under `### Fixed`.
- `.claude-plugin/plugin.json` + `marketplace.json` — version sync 3.3.1 → 3.3.2.

## Out of scope (consciously left alone)

- README line 110/129/233/393/405 — contextual ADR-001/002 references in prose. Correct as-is; not inventory drift.
- `CHANGELOG.md` historical entries — frozen records.
- `docs/adr/ADR-004`, `ADR-005` cross-references to ADR-001/002 — intentional citations, not inventory.
- `skills/governance-setup/SKILL.md` ADR-001 reference — describes the file the skill *creates*, not an inventory listing.
- `docs/compliance/*-MAPPING.md` ADR-001/002 citations — controlled compliance mappings, intentional.

Cross-checked via `grep -rn "ADR-00[1-2]" --include="*.md"` across the repo. Only the README inventory diagrams qualified as drift.

## Test plan

- [x] `bash tests/validate-plugin.sh --skip-install-check` → 79 PASS / 0 FAIL / 1 SKIP.
- [x] `grep -cn "D2\[" README.md` → 1 occurrence (no duplicate D2 declaration).
- [x] `grep -c "ADR-00[3-6]" README.md` → ADR-003..ADR-006 all present in tree.
- [x] Version sync: `plugin.json` + `marketplace.json` + `CHANGELOG.md` all show `3.3.2`.

## Refs

- Closes #33
- Audit origin: 8-habit-reviewer review of PR #32 (2026-05-11)
- Precedent commit: c667f89 (v3.3.1 docs-only release)