### PR TITLE
docs(readme): inline ETCLOVG 7-layer coverage table

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,34 @@ Understand ──> Specify ──> Plan ──> Implement ──> Verify
 
 → **[docs/architecture/etclovg-coverage.md](docs/architecture/etclovg-coverage.md)** — ETCLOVG 7-layer taxonomy coverage map (Agent Harness Engineering). Anchor for future scope-expansion decisions: `G` strong, `V/L/C` partial, `O` none, `E/T` out-of-scope by charter / plugin boundary.
 
+### Agent Harness Coverage (ETCLOVG)
+
+`Agent = Model + Harness`. The **ETCLOVG taxonomy** (Agent Harness Engineering, 2026) defines 7 layers that wrap a model to make it a reliable autonomous agent: **E**xecution, **T**ooling, **C**ontext+Memory, **L**ifecycle, **O**bservability, **V**erification, **G**overnance. This plugin's per-layer coverage:
+
+| Layer                             |        Status         | What ships today                                                                                                                                                                                                                                     | Gap / Why not                                                                     |
+| --------------------------------- | :-------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **E** — Execution Environment     |     `OOS-charter`     | —                                                                                                                                                                                                                                                    | "Skills are read-only guidance" — charter-amendment ADR required to re-evaluate   |
+| **T** — Tooling (MCP / A2A)       | `OOS-plugin-boundary` | —                                                                                                                                                                                                                                                    | Routed to sibling plugin `pitimon/devsecops-ai-team` (plugin boundary)            |
+| **C** — Context & Memory          |       `Partial`       | `hooks/session-start.sh` (~360 tokens/session — Progressive Disclosure); skills lazy-load on `/command`                                                                                                                                              | No Compaction or Context Resets                                                   |
+| **L** — Lifecycle & Orchestration |       `Partial`       | Three Loops + Consequence Override (ADR-002) — autonomy classification with irreversible-op gating                                                                                                                                                   | No multi-agent orchestration or Planner-Generator-Evaluator structural separation |
+| **O** — Observability             |        `None`         | —                                                                                                                                                                                                                                                    | No trace / telemetry / SLA metrics — awaiting first-person friction signal        |
+| **V** — Verification              |       `Partial`       | 31 fitness functions (pre-commit / pre-PR / architecture), `governance-reviewer` agent, `validate-plugin.sh` (80 checks)                                                                                                                             | "Verify Before You Fix" sandbox gate not yet codified                             |
+| **G** — Governance & Security     |     **`Strong`**      | (1) Three Loops + Consequence Override (ADR-002) · (2) `secret-scanner.sh` 25 BLOCK + 3 WARN · (3) `governance-reviewer` agent · (4) 31 governance checks · (5) Compliance mappings: EU AI Act / ISO 42001 / NIST AI RMF / OWASP DSGAI (11 controls) | — primary focus                                                                   |
+
+**Coverage summary**:
+
+| Status                | Count | Layers  |
+| --------------------- | ----: | ------- |
+| `Strong`              |     1 | G       |
+| `Partial`             |     3 | C, L, V |
+| `None`                |     1 | O       |
+| `OOS-charter`         |     1 | E       |
+| `OOS-plugin-boundary` |     1 | T       |
+
+> **Friction-first**: `Partial` is not an invitation to expand. Per ADR-014 in `8-habit-ai-dev`, pattern attractiveness alone is not a shipping criterion — a first-person friction case (issue, lesson, post-mortem) must be cited before any `Partial` → `Strong` move.
+>
+> **Adopter shorthand**: use `claude-governance` for **G strong** + **V/L/C partial**. For **E (sandbox)** or **T (MCP)**, pair with [`pitimon/devsecops-ai-team`](https://github.com/pitimon/devsecops-ai-team).
+
 ---
 
 ## Token Budget


### PR DESCRIPTION
## Summary

Add a per-layer **ETCLOVG (Agent Harness Engineering)** coverage table inline in the README Architecture section, sourced from [`docs/architecture/etclovg-coverage.md`](docs/architecture/etclovg-coverage.md) (canonical SSOT). README readers no longer need to navigate to the detail doc to see the high-level coverage verdict.

## What changed

- New `### Agent Harness Coverage (ETCLOVG)` subsection placed directly under the existing `### Architecture` diagram + `etclovg-coverage.md` link line.
- **Per-layer table** (E / T / C / L / O / V / G): Status, "What ships today", Gap / Why not.
- **Coverage summary table**: count by status — `Strong` × 1 (G) · `Partial` × 3 (C, L, V) · `None` × 1 (O) · `OOS-charter` × 1 (E) · `OOS-plugin-boundary` × 1 (T).
- **Friction-first reminder** (ADR-014 in `8-habit-ai-dev`) — `Partial` is not an invitation to expand.
- **Adopter shorthand** — when to pair with `pitimon/devsecops-ai-team` for **E** (sandbox) or **T** (MCP) layers.

## Why inline (not just a link)

The existing `→ etclovg-coverage.md` link line (`README.md:L293`) only described the verdict in prose — readers had to either trust the prose or click through. The table makes the verdict scannable in the README itself while the link still points to the per-layer evidence/rationale in the SSOT doc. SSOT discipline preserved: README mirrors the conclusion, detail doc remains authoritative for evidence and maintenance contracts.

## Content faithfulness

All seven layer verdicts and the count-summary numbers mirror `docs/architecture/etclovg-coverage.md` (as of v3.3.3 / ETCLOVG Phase 1). No new claims introduced. Companion-plugin reference (`pitimon/devsecops-ai-team`) is the same one already cited in the Companion Plugins section (`README.md:L399-401`).

## Test plan

- [x] `bash tests/validate-plugin.sh --skip-install-check` → **PASS 79 / FAIL 0 / SKIP 1** (CI signal intact)
- [x] Diff: `+28 insertions, 0 deletions` — purely additive
- [x] Section placement: under existing Architecture subsection, before `## Token Budget` — natural reading flow
- [ ] CI: validate workflow passes on this PR

Refs `docs/architecture/etclovg-coverage.md`