### PR TITLE
docs(maintenance): ETCLOVG README↔canonical mirror sync (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ Understand ──> Specify ──> Plan ──> Implement ──> Verify
 
 ### Agent Harness Coverage (ETCLOVG)
 
+<!-- Mirror of docs/architecture/etclovg-coverage.md § Per-layer coverage (single source of truth). Update both in the same PR to avoid drift. See issue #46. -->
+
 `Agent = Model + Harness`. The **ETCLOVG taxonomy** (Agent Harness Engineering, 2026) defines 7 layers that wrap a model to make it a reliable autonomous agent: **E**xecution, **T**ooling, **C**ontext+Memory, **L**ifecycle, **O**bservability, **V**erification, **G**overnance. This plugin's per-layer coverage:
 
 | Layer                             |        Status         | What ships today                                                                                                                                                                                                                                     | Gap / Why not                                                                     |

--- a/docs/architecture/etclovg-coverage.md
+++ b/docs/architecture/etclovg-coverage.md
@@ -90,6 +90,7 @@ These are the canonical external references for the ETCLOVG taxonomy and its com
 ## Maintenance
 
 - **Review trigger**: any new ADR that adds, expands, or changes architecture decisions affecting layer coverage updates this map in the same PR. This is recorded as a fitness-function-style expectation here, not enforced by a CI check.
+- **README mirror sync**: a condensed copy of the per-layer verdict table is inlined in `README.md` § "Agent Harness Coverage (ETCLOVG)" (added v3.3.5, PR #44). **This document is the single source of truth** — any change to a layer's `Status` here MUST update the README table in the same PR, or the two drift (the doc-drift class PR #43 fixed in v3.3.5).
 - **Drop date / next full re-evaluation**: **2026-11-26** (6 months from creation). At that point: if no layer status has shifted and no friction signal has arrived for any `Partial`/`None` layer, mark this map as "stable" and extend review interval. Otherwise refresh the Evidence column to reflect current state.
 - **Source-snapshot dependency**: this map cites NotebookLM notebook `0f90fcee` as of 2026-05-24. If the notebook is re-curated and the ETCLOVG layer names or responsibilities drift, validate the per-layer rows against the new taxonomy before refreshing.
 - **Charter alignment**: any move from `OOS-charter` to a non-OOS status requires a new ADR amending the read-only-guidance principle stated in `pitimon/8-habit-ai-dev/CLAUDE.md` §50-67.


### PR DESCRIPTION
## Summary

Fix [#46](https://github.com/pitimon/claude-governance/issues/46): institutionalize the mirror-sync rule for the ETCLOVG 7-layer verdict table after [#44](https://github.com/pitimon/claude-governance/pull/44) (v3.3.5) inlined it in `README.md`.

Two surgical hunks (3 lines total, purely additive):

1. **`docs/architecture/etclovg-coverage.md`** — Maintenance section gains a "README mirror sync" bullet declaring this doc the **single source of truth** and requiring any layer-`Status` change to update the README table in the same PR.
2. **`README.md`** — HTML comment above the `### Agent Harness Coverage (ETCLOVG)` section points back to the canonical SSOT and cites #46. Invisible to rendered output; visible at edit time, which is when it matters.

## Why this matters

PR #44 (v3.3.5) added the inline README table for adopter discoverability — but the canonical map's existing Maintenance bullet (*"any new ADR … updates this map in the same PR"*) only pointed at the canonical copy. A future ADR that shifts a layer's Status would update the canonical table and silently leave the README copy stale. **Same doc-drift failure class that PR #43 just fixed in v3.3.5.** Reporter (#46) caught this on cross-verify of v3.3.5 — clean otherwise at 15/15 (100%).

This is exactly the "deposit not withdrawal" move (H4): a 3-line patch now prevents an unbounded future drift cost. Friction-first applies (ADR-014): this *is* the n=1 friction case (#46 itself).

## What this is not

- **Not** a CI check. The canonical map's existing language ("not enforced by a CI check") stays accurate. Per [#46](https://github.com/pitimon/claude-governance/issues/46) Hybrid option, a tests/validate-plugin.sh row-count assertion is a possible follow-up if a second drift incident surfaces — held back per friction-first.
- **Not** a content change. No table row, count, or verdict moved. The two tables remain consistent (verified — same Strong=1 G, Partial=3 C/L/V, None=1 O, OOS=2 E/T).
- **Not** PR #44 reverted. The README inline table stays for adopter scannability — option B (drop the inline) was rejected per H7 (the discoverability gain from inlining is the reason PR #44 shipped).

## Test plan

- [x] `bash tests/validate-plugin.sh --skip-install-check` → **PASS 79 / FAIL 0 / SKIP 1** (CI signal intact)
- [x] Canonical map carries "single source of truth" SSOT declaration
- [x] README ETCLOVG section carries the mirror HTML comment
- [x] No table row/verdict change in either file (verified via `git diff` — only the new bullet + new comment added)
- [ ] CI: validate workflow passes on this PR

## Release implication

Docs-only patch; consistent with v3.3.2 / v3.3.3 / v3.3.5 docs-only release pattern. Whether to ship as v3.3.6 or batch with the next change is maintainer's call.

Refs #46, #44, #43