### PR TITLE
chore(release): v3.3.6 — institutionalize ETCLOVG mirror-sync rule (#46)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "claude-governance",
       "description": "Governance framework with hooks (secret scanner, governance context), skills (/governance-check, /create-adr, /spec-driven-dev, /governance-setup), and agent (governance-reviewer)",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "author": {
         "name": "pitimon"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Complete governance framework for Claude Code — fitness functions, secret scanning, spec-driven development, ADR system, and Three Loops decision model",
   "author": {
     "name": "pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.6] - 2026-05-25
+
+### Changed
+
+- **Institutionalize the ETCLOVG README↔canonical mirror-sync rule** (issue [#46](https://github.com/pitimon/claude-governance/issues/46), PR [#47](https://github.com/pitimon/claude-governance/pull/47)). v3.3.5 PR [#44](https://github.com/pitimon/claude-governance/pull/44) inlined the 7-layer ETCLOVG verdict table in `README.md` for adopter discoverability, but the canonical map's Maintenance section did not acknowledge the mirror — so a future ADR that shifted a layer's `Status` could update the canonical table and silently leave the README copy stale (same doc-drift failure class that v3.3.5 PR [#43](https://github.com/pitimon/claude-governance/pull/43) just fixed). Two surgical hunks (3 lines total, additive only):
+  - `docs/architecture/etclovg-coverage.md` Maintenance section gains a **"README mirror sync"** bullet declaring this doc the **single source of truth** and requiring any layer-`Status` change to update the README table in the same PR.
+  - `README.md` § "Agent Harness Coverage (ETCLOVG)" carries an HTML comment above the section pointing back to the canonical SSOT and citing #46.
+
+  No table row / count / verdict moved. Both tables remain consistent (Strong=1 G, Partial=3 C/L/V, None=1 O, OOS=2 E/T). This is a fitness-function-style expectation (per the canonical map's "not enforced by a CI check" language); a CI row-count assertion is held back per ADR-014 friction-first discipline (in `8-habit-ai-dev`) — promote to "ship" only on a second drift incident.
+
+### Verification
+
+- `bash tests/validate-plugin.sh --skip-install-check` → PASS 79 / FAIL 0 / SKIP 1 (CI signal intact).
+- `bash tests/test-secret-scanner.sh` → PASS 40 / FAIL 0.
+- `bash tests/test-release-qa.sh` → PASS 162 / FAIL 0 / WARN 0.
+
+No production code, skill, hook, or runtime change — docs-only patch release for drift prevention. Consistent with the v3.3.2 / v3.3.3 / v3.3.5 docs-only release precedent.
+
 ## [3.3.5] - 2026-05-25
 
 ### Changed


### PR DESCRIPTION
## Summary

- Bump `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` from **3.3.5 → 3.3.6**.
- CHANGELOG entry under `## [3.3.6]` covering [#47](https://github.com/pitimon/claude-governance/pull/47) (closes [#46](https://github.com/pitimon/claude-governance/issues/46)): canonical ETCLOVG map gains "README mirror sync" Maintenance bullet declaring SSOT + same-PR update rule; README ETCLOVG section carries HTML comment pointing back to canonical doc.
- 3 lines additive across 2 files in the underlying fix; no table content / row / verdict moved.

## Why a release

Docs-only patch release for **doc-drift prevention** — institutionalizes a rule that already failed once (PR #44 inlined the table without updating the canonical map's Maintenance section). Same release pattern as **v3.3.2** (#33 ADR catalog) / **v3.3.3** (ETCLOVG coverage map) / **v3.3.5** (mermaid→ASCII + ETCLOVG inline). No production code, skill, hook, or runtime change.

Friction-first satisfied: #46 itself is the n=1 friction case (per ADR-014 in `8-habit-ai-dev`); CI assertion (Hybrid option from #46) held back to "ship on second drift incident."

## Test plan

- [x] Local: `bash tests/validate-plugin.sh --skip-install-check` → **PASS 79 / FAIL 0 / SKIP 1**
- [x] Local: `bash tests/test-secret-scanner.sh` → **PASS 40 / FAIL 0**
- [x] Local: `bash tests/test-release-qa.sh` → **PASS 162 / FAIL 0 / WARN 0**
- [x] Version sync: `plugin.json=3.3.6` ↔ `marketplace.json=3.3.6`
- [ ] CI: validate workflow passes on this PR
- [ ] Post-merge: tag `v3.3.6` + publish GitHub release + close #46 with rationale

Refs #46, #47