### PR TITLE
fix: Codex hook-config schema purity (v3.4.2) (#51)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "claude-governance",
       "description": "Governance framework with hooks (secret scanner, governance context), skills (/governance-check, /create-adr, /spec-driven-dev, /governance-setup), and agent (governance-reviewer)",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "author": {
         "name": "pitimon"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Complete governance framework for Claude Code — fitness functions, secret scanning, spec-driven development, ADR system, and Three Loops decision model",
   "author": {
     "name": "pitimon",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This is your install + operating protocol. Claude Code reads `./CLAUDE.md` autom
 
 ## Trust boundary
 
-Skills are guidance that an agent executes under the user's authority. Claude Code hooks provide local enforcement for Claude Code only. In Codex, use the skills as explicit checklists and workflows; do not assume `hooks/session-start.sh` or `hooks/secret-scanner.sh` are automatically active.
+Skills are guidance that an agent executes under the user's authority. Claude Code hooks provide local enforcement for Claude Code only. In Codex, use the skills as explicit checklists and workflows; do not assume `hooks/session-start.sh` or `hooks/secret-scanner.sh` are automatically active. Note that Codex still _parses_ `hooks/hooks.json` at install with a strict schema (top level = `hooks` only — see issue #51), so that file must stay schema-pure even though Codex does not run the hooks.
 
 ## Common tasks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.2] - 2026-06-17
+
+### Added
+
+- `tests/validate-plugin.sh` check 3.2b — asserts `hooks/hooks.json` (and its `plugin/` mirror) has only a top-level `hooks` key. Forcing function so the Codex parse-error class from #51 cannot silently return.
+
+### Changed
+
+- `AGENTS.md` clarifies that Codex still _parses_ `hooks/hooks.json` at install (strict schema) even though it does not run the hooks, so the file must stay schema-pure.
+
+### Fixed
+
+- **Codex hook-config parse failure** ([#51](https://github.com/pitimon/claude-governance/issues/51)) — removed the top-level `description` field from `hooks/hooks.json` (and its `plugin/` mirror). Codex auto-discovers and parses `hooks/hooks.json` at install/cache time with a strict schema that accepts only a top-level `hooks` key, so the sibling `description` made Codex reject the config: `unknown field 'description', expected 'hooks'`. Claude Code tolerated the extra key; Codex does not. `jq empty` still passes.
+
 ## [3.4.1] - 2026-06-08
 
 ### Fixed

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Governance hooks — inject governance context at session start and scan for hardcoded secrets before file writes",
   "hooks": {
     "SessionStart": [
       {

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/plugin/AGENTS.md
+++ b/plugin/AGENTS.md
@@ -21,7 +21,7 @@ This is your install + operating protocol. Claude Code reads `./CLAUDE.md` autom
 
 ## Trust boundary
 
-Skills are guidance that an agent executes under the user's authority. Claude Code hooks provide local enforcement for Claude Code only. In Codex, use the skills as explicit checklists and workflows; do not assume `hooks/session-start.sh` or `hooks/secret-scanner.sh` are automatically active.
+Skills are guidance that an agent executes under the user's authority. Claude Code hooks provide local enforcement for Claude Code only. In Codex, use the skills as explicit checklists and workflows; do not assume `hooks/session-start.sh` or `hooks/secret-scanner.sh` are automatically active. Note that Codex still _parses_ `hooks/hooks.json` at install with a strict schema (top level = `hooks` only — see issue #51), so that file must stay schema-pure even though Codex does not run the hooks.
 
 ## Common tasks
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.2] - 2026-06-17
+
+### Added
+
+- `tests/validate-plugin.sh` check 3.2b — asserts `hooks/hooks.json` (and its `plugin/` mirror) has only a top-level `hooks` key. Forcing function so the Codex parse-error class from #51 cannot silently return.
+
+### Changed
+
+- `AGENTS.md` clarifies that Codex still _parses_ `hooks/hooks.json` at install (strict schema) even though it does not run the hooks, so the file must stay schema-pure.
+
+### Fixed
+
+- **Codex hook-config parse failure** ([#51](https://github.com/pitimon/claude-governance/issues/51)) — removed the top-level `description` field from `hooks/hooks.json` (and its `plugin/` mirror). Codex auto-discovers and parses `hooks/hooks.json` at install/cache time with a strict schema that accepts only a top-level `hooks` key, so the sibling `description` made Codex reject the config: `unknown field 'description', expected 'hooks'`. Claude Code tolerated the extra key; Codex does not. `jq empty` still passes.
+
 ## [3.4.1] - 2026-06-08
 
 ### Fixed

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Governance hooks — inject governance context at session start and scan for hardcoded secrets before file writes",
   "hooks": {
     "SessionStart": [
       {

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -240,6 +240,26 @@ for hook_script in "$HOOKS_DIR/session-start.sh" "$HOOKS_DIR/secret-scanner.sh";
   fi
 done
 
+# 3.2b hooks/hooks.json top-level schema purity (Codex compat, issue #51)
+# Codex auto-discovers and parses hooks/hooks.json at install with a strict
+# schema that accepts ONLY a top-level "hooks" key. Any sibling key (e.g. a
+# "description") makes Codex reject the config: "unknown field `description`,
+# expected `hooks`". Claude Code tolerates it; Codex does not. Keep the top
+# level schema-pure so the same file installs cleanly in both runtimes.
+for hookcfg in "$HOOKS_DIR/hooks.json" "$CODEX_CHILD_DIR/hooks/hooks.json"; do
+  [[ -f "$hookcfg" ]] || continue
+  cfg_name="${hookcfg#$REPO_ROOT/}"
+  extra_keys=$(python3 -c "import json; d=json.load(open('$hookcfg')); print(' '.join(k for k in d if k != 'hooks'))" 2>/dev/null)
+  has_hooks=$(python3 -c "import json; print('yes' if 'hooks' in json.load(open('$hookcfg')) else 'no')" 2>/dev/null)
+  if [[ -n "$extra_keys" ]]; then
+    fail "$cfg_name has non-'hooks' top-level key(s); Codex rejects unknown fields (#51): $extra_keys"
+  elif [[ "$has_hooks" == "yes" ]]; then
+    pass "$cfg_name top level is schema-pure (only 'hooks')"
+  else
+    fail "$cfg_name missing top-level 'hooks' key"
+  fi
+done
+
 # 3.3 Required example files
 EXPECTED_EXAMPLES=("DOMAIN.md.example" "adr-template.md" "project-claude-md.example")
 for ex in "${EXPECTED_EXAMPLES[@]}"; do


### PR DESCRIPTION
## Summary

Closes #51 — Codex CLI rejects the plugin's `hooks/hooks.json` at install because it carries a top-level `description` field.

**Root cause**: Codex auto-discovers and *parses* `hooks/hooks.json` at install/cache time with a strict schema that accepts **only** a top-level `hooks` key. The sibling `description` triggers `unknown field 'description', expected 'hooks'`. Claude Code tolerates the extra key; Codex does not. (Same class as `8-habit-ai-dev` #321, fixed in parallel.)

- **Fix** — removed top-level `description` from `hooks/hooks.json` (+ `plugin/` mirror). `jq empty` still passes; top-level keys = `["hooks"]`.
- **Forcing function** — new `tests/validate-plugin.sh` check **3.2b** fails if `hooks/hooks.json` (or its mirror) carries any non-`hooks` top-level key. python3-based (matches the repo's `json_field`/`json_valid` helpers), negative-tested.
- **Doctrine note** — `AGENTS.md` now states Codex *parses* `hooks.json` at install even though it does not run the hooks. Verified `hooks/session-start.sh` has **no** Codex-aware execution code (emits standard Claude Code `hookSpecificOutput` unconditionally), so "Claude Code hooks do not run in Codex" remains accurate — no broader doctrine reconcile needed.
- **Version** — 3.4.1 → 3.4.2 across all 4 manifests + CHANGELOG. (`bump-version.sh` covers 3; `plugin/.codex-plugin/plugin.json` bumped manually — the validator's version-sync check already guards that child-manifest gap, so fixing the script is out of scope here.)

`.codex-plugin/plugin.json`'s `description` field is left untouched — that manifest's schema is permissive (only `hooks.json` has the strict `deny_unknown_fields` schema).

## Test plan

- [x] `validate-plugin.sh --skip-install-check` — 115 PASS / 0 FAIL (incl. new 3.2b for both files)
- [x] `test-release-qa.sh` — 166 PASS / 0 FAIL
- [x] `test-secret-scanner.sh` — 40 PASS / 0 FAIL
- [x] Check 3.2b **negative test**: injecting `description` → 3.2b FAILS as designed
- [x] `jq` valid; top-level keys = `["hooks"]`
- [x] All 3 mirrored files (hooks.json, AGENTS.md, CHANGELOG.md) byte-identical
- [x] All 4 version manifests synced at 3.4.2

Closes #51