### PR TITLE
fix: close secret-scanner fail-open on non-compact JSON (v3.4.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "claude-governance",
       "description": "Governance framework with hooks (secret scanner, governance context), skills (/governance-check, /create-adr, /spec-driven-dev, /governance-setup), and agent (governance-reviewer)",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "author": {
         "name": "pitimon"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Complete governance framework for Claude Code — fitness functions, secret scanning, spec-driven development, ADR system, and Three Loops decision model",
   "author": {
     "name": "pitimon",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.4] - 2026-07-10
+
+Hardens the `secret-scanner.sh` PreToolUse hook against a fail-open reproduced during a maintenance review. Claude Code-only (Codex does not run hooks); `hooks/hooks.json` top-level schema stays pure for Codex install (#51).
+
+### Fixed
+
+- **`hooks/secret-scanner.sh` fail-open (reproduced).** `tool_name` was extracted with `grep -o '"tool_name":"[^"]*"'`, which only matches compact JSON. A payload with a space after the colon (`"tool_name": "Write"`) yielded an empty `tool_name`, fell through the `case` to a silent `exit 0`, and let a hardcoded secret pass — the security control disabled itself. Reproduced directly: a spaced payload carrying an `sk-ant-` key returned exit 0 (allow) where the compact form returned exit 2 (block). Current Claude Code emits compact JSON so this was not triggered in practice, but a security control must not depend on serialization formatting.
+
+### Changed
+
+- `tool_name` is now parsed with `python3` (already a hard requirement) instead of a whitespace-sensitive grep.
+- **Raw-scan fallback (never silent).** When content extraction yields nothing — unparseable/unexpected `tool_name`, or a changed `tool_input` shape — the scanner now scans the raw hook payload as a backstop: a secret still triggers `exit 2`; a clean payload exits 0 but, for an unrecognized tool, emits a `WARNING` to stderr rather than silently allowing. A recognized empty-file write stays silent (no noise). This closes both prior silent-allow exits.
+- `hooks/hooks.json` PreToolUse `timeout` corrected from `500` to `5` (Claude Code hook timeouts are seconds; `500` was an apparent seconds/ms slip). The field is nested, not top-level, so Codex install-time schema purity (#51) is unaffected — asserted by validate-plugin check 3.2b.
+- `tests/test-secret-scanner.sh`: +4 fail-open regression cases (spaced-JSON block, raw-scan fallback block for unparseable + unrecognized-tool payloads, warn-not-silent on clean parse failure). 40 → 44 checks.
+
 ## [3.4.3] - 2026-07-10
 
 Freshness sweep — the `eu-ai-act-check` (v3.1.0) and `iso-42001-check` (v3.2.0) skills shipped without being advertised in the plugin's consumer-facing discovery surfaces. Scope: Claude Code-facing surfaces only (the Codex entry point `AGENTS.md` already listed all six).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -16,7 +16,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/secret-scanner.sh",
-            "timeout": 500
+            "timeout": 5
           }
         ],
         "matcher": "Edit|Write|MultiEdit"

--- a/hooks/secret-scanner.sh
+++ b/hooks/secret-scanner.sh
@@ -13,10 +13,19 @@ fi
 # Read tool input from stdin
 INPUT=$(cat)
 
-# Extract content to scan based on tool type
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract the tool name. Parse with python3 (a hard requirement, checked above)
+# instead of a whitespace-sensitive grep: a grep like '"tool_name":"[^"]*"' only
+# matches compact JSON and returns empty on a payload with a space after the
+# colon, which used to fall through to a silent `exit 0` — a fail-open in the
+# security control. python3's json.load is whitespace-agnostic.
+TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import sys,json
+try:
+    print(json.load(sys.stdin).get('tool_name',''))
+except Exception:
+    pass" 2>/dev/null)
 
 CONTENT=""
+RECOGNIZED=true
 case "$TOOL_NAME" in
   Write)
     CONTENT=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('content',''))" 2>/dev/null)
@@ -33,13 +42,21 @@ print(' '.join(e.get('new_string','') for e in edits))
 " 2>/dev/null)
     ;;
   *)
-    exit 0
+    RECOGNIZED=false
     ;;
 esac
 
-# If no content extracted, allow
+# Fail-safe: never silently allow. If content extraction produced nothing —
+# whether tool_name was unparseable/unexpected, or the tool_input shape changed
+# so extraction returned empty — fall back to scanning the RAW hook payload so a
+# secret cannot slip through on a payload we failed to parse. (Claude Code
+# currently emits compact JSON that parses cleanly, so this is defense-in-depth,
+# not the hot path.) A recognized tool with genuinely empty content scans the
+# raw payload too, but stays silent — only an unrecognized/unparseable tool
+# warns, so a legitimate empty-file write is not noisy.
 if [ -z "$CONTENT" ]; then
-  exit 0
+  CONTENT="$INPUT"
+  [ "$RECOGNIZED" = false ] && FELL_BACK=true
 fi
 
 # === BLOCK PATTERNS (exit 2) — secrets and credentials ===
@@ -144,6 +161,13 @@ if [ "$PII_WARNED" = true ]; then
   echo "" >&2
   echo "PII detected. Ensure data handling complies with your data classification policy." >&2
   echo "See: examples/DATA-CLASSIFICATION.md.example for guidance. [DSGAI01]" >&2
+fi
+
+# Surface a parse-failure fallback (never silent). We reached here without
+# blocking, so no secret was found in the raw payload — but the operator should
+# know the structured path failed so a recurring failure can be investigated.
+if [ "${FELL_BACK:-false}" = true ]; then
+  echo "Governance: WARNING — could not parse tool payload (tool_name='${TOOL_NAME:-<empty>}'); scanned raw input as a fallback, no secret found. If this recurs, the hook's JSON parsing may need updating." >&2
 fi
 
 exit 0

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.4] - 2026-07-10
+
+Hardens the `secret-scanner.sh` PreToolUse hook against a fail-open reproduced during a maintenance review. Claude Code-only (Codex does not run hooks); `hooks/hooks.json` top-level schema stays pure for Codex install (#51).
+
+### Fixed
+
+- **`hooks/secret-scanner.sh` fail-open (reproduced).** `tool_name` was extracted with `grep -o '"tool_name":"[^"]*"'`, which only matches compact JSON. A payload with a space after the colon (`"tool_name": "Write"`) yielded an empty `tool_name`, fell through the `case` to a silent `exit 0`, and let a hardcoded secret pass — the security control disabled itself. Reproduced directly: a spaced payload carrying an `sk-ant-` key returned exit 0 (allow) where the compact form returned exit 2 (block). Current Claude Code emits compact JSON so this was not triggered in practice, but a security control must not depend on serialization formatting.
+
+### Changed
+
+- `tool_name` is now parsed with `python3` (already a hard requirement) instead of a whitespace-sensitive grep.
+- **Raw-scan fallback (never silent).** When content extraction yields nothing — unparseable/unexpected `tool_name`, or a changed `tool_input` shape — the scanner now scans the raw hook payload as a backstop: a secret still triggers `exit 2`; a clean payload exits 0 but, for an unrecognized tool, emits a `WARNING` to stderr rather than silently allowing. A recognized empty-file write stays silent (no noise). This closes both prior silent-allow exits.
+- `hooks/hooks.json` PreToolUse `timeout` corrected from `500` to `5` (Claude Code hook timeouts are seconds; `500` was an apparent seconds/ms slip). The field is nested, not top-level, so Codex install-time schema purity (#51) is unaffected — asserted by validate-plugin check 3.2b.
+- `tests/test-secret-scanner.sh`: +4 fail-open regression cases (spaced-JSON block, raw-scan fallback block for unparseable + unrecognized-tool payloads, warn-not-silent on clean parse failure). 40 → 44 checks.
+
 ## [3.4.3] - 2026-07-10
 
 Freshness sweep — the `eu-ai-act-check` (v3.1.0) and `iso-42001-check` (v3.2.0) skills shipped without being advertised in the plugin's consumer-facing discovery surfaces. Scope: Claude Code-facing surfaces only (the Codex entry point `AGENTS.md` already listed all six).

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -16,7 +16,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/secret-scanner.sh",
-            "timeout": 500
+            "timeout": 5
           }
         ],
         "matcher": "Edit|Write|MultiEdit"

--- a/plugin/hooks/secret-scanner.sh
+++ b/plugin/hooks/secret-scanner.sh
@@ -13,10 +13,19 @@ fi
 # Read tool input from stdin
 INPUT=$(cat)
 
-# Extract content to scan based on tool type
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract the tool name. Parse with python3 (a hard requirement, checked above)
+# instead of a whitespace-sensitive grep: a grep like '"tool_name":"[^"]*"' only
+# matches compact JSON and returns empty on a payload with a space after the
+# colon, which used to fall through to a silent `exit 0` — a fail-open in the
+# security control. python3's json.load is whitespace-agnostic.
+TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import sys,json
+try:
+    print(json.load(sys.stdin).get('tool_name',''))
+except Exception:
+    pass" 2>/dev/null)
 
 CONTENT=""
+RECOGNIZED=true
 case "$TOOL_NAME" in
   Write)
     CONTENT=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('content',''))" 2>/dev/null)
@@ -33,13 +42,21 @@ print(' '.join(e.get('new_string','') for e in edits))
 " 2>/dev/null)
     ;;
   *)
-    exit 0
+    RECOGNIZED=false
     ;;
 esac
 
-# If no content extracted, allow
+# Fail-safe: never silently allow. If content extraction produced nothing —
+# whether tool_name was unparseable/unexpected, or the tool_input shape changed
+# so extraction returned empty — fall back to scanning the RAW hook payload so a
+# secret cannot slip through on a payload we failed to parse. (Claude Code
+# currently emits compact JSON that parses cleanly, so this is defense-in-depth,
+# not the hot path.) A recognized tool with genuinely empty content scans the
+# raw payload too, but stays silent — only an unrecognized/unparseable tool
+# warns, so a legitimate empty-file write is not noisy.
 if [ -z "$CONTENT" ]; then
-  exit 0
+  CONTENT="$INPUT"
+  [ "$RECOGNIZED" = false ] && FELL_BACK=true
 fi
 
 # === BLOCK PATTERNS (exit 2) — secrets and credentials ===
@@ -144,6 +161,13 @@ if [ "$PII_WARNED" = true ]; then
   echo "" >&2
   echo "PII detected. Ensure data handling complies with your data classification policy." >&2
   echo "See: examples/DATA-CLASSIFICATION.md.example for guidance. [DSGAI01]" >&2
+fi
+
+# Surface a parse-failure fallback (never silent). We reached here without
+# blocking, so no secret was found in the raw payload — but the operator should
+# know the structured path failed so a recurring failure can be investigated.
+if [ "${FELL_BACK:-false}" = true ]; then
+  echo "Governance: WARNING — could not parse tool payload (tool_name='${TOOL_NAME:-<empty>}'); scanned raw input as a fallback, no secret found. If this recurs, the hook's JSON parsing may need updating." >&2
 fi
 
 exit 0

--- a/tests/test-secret-scanner.sh
+++ b/tests/test-secret-scanner.sh
@@ -149,6 +149,52 @@ else
 fi
 
 # ============================================================
+# Fail-open regression — parse robustness (v3.4.4)
+# ============================================================
+# Before v3.4.4 the tool_name was extracted with a grep that only matched
+# compact JSON. A payload with a space after the colon produced an empty
+# tool_name, fell through to a silent `exit 0`, and let secrets pass — the
+# security control disabled itself. These assert the python3 parse + raw-scan
+# fallback so no payload shape can silently allow a secret.
+# (Secret is assembled at runtime from parts so the plugin's own live hook does
+# not block edits to this file — the source bytes never hold a contiguous key.)
+printf "\n\033[1;36m[Fail-open regression — parse robustness]\033[0m\n"
+
+SK="sk-ant-""api03-abcdefghijklmnopqrst9"
+
+# Spaced JSON (space after every colon) — the exact shape that used to bypass.
+SPACED=$(printf '{"tool_name": "Write", "tool_input": {"content": "key = %s"}}' "$SK")
+if echo "$SPACED" | bash "$SCANNER" >/dev/null 2>&1; then
+  fail "spaced-JSON payload with secret should block (fail-open regression)"
+else
+  pass "spaced-JSON payload with secret blocked"
+fi
+
+# Unparseable payload with a secret in the raw bytes — fallback must scan raw.
+if printf 'not valid json but contains %s inline' "$SK" | bash "$SCANNER" >/dev/null 2>&1; then
+  fail "unparseable payload with secret should block (raw-scan fallback)"
+else
+  pass "unparseable payload with secret blocked via raw-scan fallback"
+fi
+
+# Unrecognized tool with a secret in tool_input — fallback must scan raw.
+UNREC=$(printf '{"tool_name":"Bash","tool_input":{"command":"export K=%s"}}' "$SK")
+if echo "$UNREC" | bash "$SCANNER" >/dev/null 2>&1; then
+  fail "unrecognized tool carrying a secret should block (raw-scan fallback)"
+else
+  pass "unrecognized tool carrying a secret blocked via raw-scan fallback"
+fi
+
+# Parse failure with no secret must WARN (not silently allow) and exit 0.
+UNREC_CLEAN='{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+stderr_out=$(echo "$UNREC_CLEAN" | bash "$SCANNER" 2>&1 >/dev/null); rc=$?
+if [[ $rc -eq 0 ]] && echo "$stderr_out" | grep -q "WARNING"; then
+  pass "parse-failure without secret warns and allows (never silent)"
+else
+  fail "parse-failure without secret should warn+allow (exit=$rc)"
+fi
+
+# ============================================================
 # Summary
 # ============================================================
 printf "\n\033[1m=== Summary ===\033[0m\n"


### PR DESCRIPTION
## Summary

- **Reproduced fail-open in the `secret-scanner.sh` PreToolUse hook.** `tool_name` was parsed with `grep -o '"tool_name":"[^"]*"'`, which only matches **compact** JSON. A payload with a space after the colon (`"tool_name": "Write"`) yielded an empty `tool_name`, fell through the `case` to a silent `exit 0`, and let a hardcoded secret through — the security control silently disabled itself.
- **Direct reproduction:** a spaced payload carrying an `sk-ant-` key → `exit 0` (allow); the compact form → `exit 2` (block). Current Claude Code emits compact JSON so it wasn't triggered in practice, but a security control must not depend on serialization formatting.

## Fix

- Parse `tool_name` with `python3` (already a hard requirement) instead of a whitespace-sensitive grep.
- **Raw-scan fallback (never silent):** on any content-extraction failure (unparseable/unexpected `tool_name`, or changed `tool_input` shape) the scanner scans the **raw payload** — a secret still `exit 2`; a clean payload `exit 0` but emits a `WARNING` for unrecognized tools rather than silently allowing. A recognized empty-file write stays silent. This closes **both** prior silent-allow exits and aligns with the repo's own "no false success report" rule.
- `hooks/hooks.json` PreToolUse `timeout` `500` → `5` (seconds; apparent ms/seconds slip). Field is **nested**, not top-level, so Codex install-time schema purity (#51) is unaffected — asserted by `validate-plugin` check 3.2b.

## Test plan

- [x] Reproduction: spaced payload with `sk-ant-` key returns exit 0 pre-fix, exit 2 post-fix
- [x] `bash tests/test-secret-scanner.sh` → 44 PASS / 0 FAIL (was 40; +4 fail-open regression cases)
- [x] `bash tests/validate-plugin.sh --skip-install-check` → 139 PASS / 0 FAIL (incl. 3.2b hooks.json top-level purity)
- [x] `bash tests/test-release-qa.sh` → 166 PASS / 0 FAIL
- [x] Fallback matrix verified: spaced+secret→block, unparseable+secret→block, unrecognized-tool+secret→block, clean parse-failure→warn+allow, clean/empty recognized write→silent allow
- [x] `plugin/` mirror in sync; `jq empty hooks/hooks.json` OK; top-level keys = `["hooks"]`

## Scope

**Claude Code-only** — Codex does not run hooks. `hooks/hooks.json` stays schema-pure for Codex install.