### PR TITLE
fix(#49): governance-reviewer uses model: inherit (v3.4.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "claude-governance",
       "description": "Governance framework with hooks (secret scanner, governance context), skills (/governance-check, /create-adr, /spec-driven-dev, /governance-setup), and agent (governance-reviewer)",
-      "version": "3.4.4",
+      "version": "3.4.5",
       "author": {
         "name": "pitimon"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "Complete governance framework for Claude Code — fitness functions, secret scanning, spec-driven development, ADR system, and Three Loops decision model",
   "author": {
     "name": "pitimon",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5] - 2026-07-10
+
+Resolves [#49](https://github.com/pitimon/claude-governance/issues/49). Claude Code-only (Codex does not register plugin agents).
+
+### Added
+
+- `docs/adr/ADR-008-governance-reviewer-model-inherit.md` — records why the `governance-reviewer` agent uses `model: inherit` rather than a hard `opus` pin: forcing a premium tier on every invocation spends the operator's inference budget and is itself a governance smell (cost/consequence tradeoffs belong to the operator, per ADR-002). Documents the downside (weaker last-gate review on a Haiku session) and the re-open condition.
+
+### Changed
+
+- `agents/governance-reviewer.md`: `model: sonnet` → `model: inherit`. The agent now runs on the tier of the invoking session; a body note directs operators to invoke release-gating reviews from an Opus-tier session so the judgment-heavy steps (§4 cross-file invariants, §5 architecture boundaries) get the stronger model, while quick checks stay cheap.
+
 ## [3.4.4] - 2026-07-10
 
 Hardens the `secret-scanner.sh` PreToolUse hook against a fail-open reproduced during a maintenance review. Claude Code-only (Codex does not run hooks); `hooks/hooks.json` top-level schema stays pure for Codex install (#51).

--- a/agents/governance-reviewer.md
+++ b/agents/governance-reviewer.md
@@ -5,13 +5,20 @@ description: >
   Use after completing a feature, before creating a PR, or when the user asks for a governance review.
   Checks: secret patterns, file/function size limits, immutability, input validation, conventional commits,
   DOMAIN.md consistency, and architecture boundaries.
-model: sonnet
+model: inherit
 tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 # Governance Reviewer
 
 You are a governance compliance reviewer. Analyze code changes against the project's governance fitness functions.
+
+> **Model tier:** this agent uses `model: inherit` — it runs on the tier of the
+> session that invokes it (see ADR-008). Steps 1–3 are mechanical pattern work;
+> the judgment-heavy parts are §4 (cross-file domain invariants) and §5
+> (architecture boundaries). For a **release-gating** review, invoke it from an
+> Opus-tier session so those steps get the stronger model; quick checks stay
+> cheap on whatever tier you are already running.
 
 ## Scope and When to Use
 

--- a/docs/adr/ADR-008-governance-reviewer-model-inherit.md
+++ b/docs/adr/ADR-008-governance-reviewer-model-inherit.md
@@ -1,0 +1,39 @@
+# ADR-008: governance-reviewer agent uses `model: inherit`
+
+## Status
+
+Accepted (2026-07-10). Resolves [#49](https://github.com/pitimon/claude-governance/issues/49).
+
+## Context
+
+The `governance-reviewer` agent (`agents/governance-reviewer.md`) was pinned to `model: sonnet`. Issue #49 asked whether it should move to Opus for deeper compliance review, since it checks cross-file domain invariants and architecture boundaries — reasoning-heavy work where a stronger model helps.
+
+The agent's review process has two kinds of work:
+
+- **Mechanical (steps 1–3):** regex secret scans, file/function size counts, debug-print greps, conventional-commit checks. Model tier is not the bottleneck here.
+- **Judgment-heavy (steps 4–5):** cross-file domain-invariant verification and architecture-boundary analysis. This is where a stronger model earns its cost.
+
+Three options were considered:
+
+1. **Keep `sonnet`** — cheap, but weakens the judgment-heavy steps on every invocation.
+2. **Hard-pin `opus`** — strongest review, but spends the *operator's* Opus budget on **every** invocation, including trivial single-file diffs. A governance plugin that unilaterally escalates its users' inference cost is itself a governance smell — cost/consequence tradeoffs belong to the operator, per this plugin's own Three Loops model (ADR-002).
+3. **`inherit`** — the agent runs on the tier of the session that invokes it.
+
+## Decision
+
+Set `model: inherit` on the `governance-reviewer` agent.
+
+The operator controls the tier by choosing the session they invoke it from: a release-gating review run from an Opus-tier session gets Opus for the judgment-heavy steps; a quick check stays cheap on whatever tier is already running. The agent body documents this ("for a release-gating review, invoke from an Opus-tier session").
+
+This keeps the model-tier decision with the operator rather than the plugin forcing a premium tier — consistent with ADR-002 (consequence-based authorization: cost/consequence tradeoffs are the operator's call).
+
+## Consequences
+
+- Release-critical reviews and cheap spot-checks both get an appropriate tier without a config change.
+- **Documented downside:** on a Haiku-tier session, the last-gate review runs on Haiku and is correspondingly weaker. Operators who need a hard floor for release gating must invoke from an Opus session (or fork a stronger session for the review). If a hard floor is ever required unconditionally, revisit this ADR — pinning `opus` is defensible, but it is a cost-policy decision and must be recorded as one.
+- `model: inherit` is a Claude Code agent-frontmatter concept. Codex does not register plugin agents (its manifest is skills-only), so this change has no effect on Codex users.
+
+## Governance
+
+- **Decision Loop**: On-the-Loop — AI proposes the model policy; the human maintainer accepts it, and the operator chooses the invoking tier per review.
+- **Fitness Function**: `grep '^model:' agents/governance-reviewer.md` returns `inherit`. Any future change back to a hard pin must cite a cost-policy rationale in a superseding ADR.

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5] - 2026-07-10
+
+Resolves [#49](https://github.com/pitimon/claude-governance/issues/49). Claude Code-only (Codex does not register plugin agents).
+
+### Added
+
+- `docs/adr/ADR-008-governance-reviewer-model-inherit.md` — records why the `governance-reviewer` agent uses `model: inherit` rather than a hard `opus` pin: forcing a premium tier on every invocation spends the operator's inference budget and is itself a governance smell (cost/consequence tradeoffs belong to the operator, per ADR-002). Documents the downside (weaker last-gate review on a Haiku session) and the re-open condition.
+
+### Changed
+
+- `agents/governance-reviewer.md`: `model: sonnet` → `model: inherit`. The agent now runs on the tier of the invoking session; a body note directs operators to invoke release-gating reviews from an Opus-tier session so the judgment-heavy steps (§4 cross-file invariants, §5 architecture boundaries) get the stronger model, while quick checks stay cheap.
+
 ## [3.4.4] - 2026-07-10
 
 Hardens the `secret-scanner.sh` PreToolUse hook against a fail-open reproduced during a maintenance review. Claude Code-only (Codex does not run hooks); `hooks/hooks.json` top-level schema stays pure for Codex install (#51).

--- a/plugin/agents/governance-reviewer.md
+++ b/plugin/agents/governance-reviewer.md
@@ -5,13 +5,20 @@ description: >
   Use after completing a feature, before creating a PR, or when the user asks for a governance review.
   Checks: secret patterns, file/function size limits, immutability, input validation, conventional commits,
   DOMAIN.md consistency, and architecture boundaries.
-model: sonnet
+model: inherit
 tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 # Governance Reviewer
 
 You are a governance compliance reviewer. Analyze code changes against the project's governance fitness functions.
+
+> **Model tier:** this agent uses `model: inherit` — it runs on the tier of the
+> session that invokes it (see ADR-008). Steps 1–3 are mechanical pattern work;
+> the judgment-heavy parts are §4 (cross-file domain invariants) and §5
+> (architecture boundaries). For a **release-gating** review, invoke it from an
+> Opus-tier session so those steps get the stronger model; quick checks stay
+> cheap on whatever tier you are already running.
 
 ## Scope and When to Use
 

--- a/plugin/docs/adr/ADR-008-governance-reviewer-model-inherit.md
+++ b/plugin/docs/adr/ADR-008-governance-reviewer-model-inherit.md
@@ -1,0 +1,39 @@
+# ADR-008: governance-reviewer agent uses `model: inherit`
+
+## Status
+
+Accepted (2026-07-10). Resolves [#49](https://github.com/pitimon/claude-governance/issues/49).
+
+## Context
+
+The `governance-reviewer` agent (`agents/governance-reviewer.md`) was pinned to `model: sonnet`. Issue #49 asked whether it should move to Opus for deeper compliance review, since it checks cross-file domain invariants and architecture boundaries — reasoning-heavy work where a stronger model helps.
+
+The agent's review process has two kinds of work:
+
+- **Mechanical (steps 1–3):** regex secret scans, file/function size counts, debug-print greps, conventional-commit checks. Model tier is not the bottleneck here.
+- **Judgment-heavy (steps 4–5):** cross-file domain-invariant verification and architecture-boundary analysis. This is where a stronger model earns its cost.
+
+Three options were considered:
+
+1. **Keep `sonnet`** — cheap, but weakens the judgment-heavy steps on every invocation.
+2. **Hard-pin `opus`** — strongest review, but spends the *operator's* Opus budget on **every** invocation, including trivial single-file diffs. A governance plugin that unilaterally escalates its users' inference cost is itself a governance smell — cost/consequence tradeoffs belong to the operator, per this plugin's own Three Loops model (ADR-002).
+3. **`inherit`** — the agent runs on the tier of the session that invokes it.
+
+## Decision
+
+Set `model: inherit` on the `governance-reviewer` agent.
+
+The operator controls the tier by choosing the session they invoke it from: a release-gating review run from an Opus-tier session gets Opus for the judgment-heavy steps; a quick check stays cheap on whatever tier is already running. The agent body documents this ("for a release-gating review, invoke from an Opus-tier session").
+
+This keeps the model-tier decision with the operator rather than the plugin forcing a premium tier — consistent with ADR-002 (consequence-based authorization: cost/consequence tradeoffs are the operator's call).
+
+## Consequences
+
+- Release-critical reviews and cheap spot-checks both get an appropriate tier without a config change.
+- **Documented downside:** on a Haiku-tier session, the last-gate review runs on Haiku and is correspondingly weaker. Operators who need a hard floor for release gating must invoke from an Opus session (or fork a stronger session for the review). If a hard floor is ever required unconditionally, revisit this ADR — pinning `opus` is defensible, but it is a cost-policy decision and must be recorded as one.
+- `model: inherit` is a Claude Code agent-frontmatter concept. Codex does not register plugin agents (its manifest is skills-only), so this change has no effect on Codex users.
+
+## Governance
+
+- **Decision Loop**: On-the-Loop — AI proposes the model policy; the human maintainer accepts it, and the operator chooses the invoking tier per review.
+- **Fitness Function**: `grep '^model:' agents/governance-reviewer.md` returns `inherit`. Any future change back to a hard pin must cite a cost-policy rationale in a superseding ADR.


### PR DESCRIPTION
## Summary

Resolves #49. The `governance-reviewer` agent was pinned to `model: sonnet`; the issue asked whether it should move to Opus for deeper compliance review.

- Set **`model: inherit`** — the agent runs on the tier of the session that invokes it. A hard `opus` pin would spend the *operator's* Opus budget on **every** invocation (including trivial single-file diffs); a governance plugin unilaterally escalating its users' inference cost is itself a governance smell. `inherit` keeps the cost/consequence tradeoff with the operator, consistent with ADR-002.
- Operator controls the tier by choosing the invoking session: release-gating review from an Opus session → Opus for the judgment-heavy steps (§4 cross-file invariants, §5 architecture boundaries); quick checks stay cheap.
- **ADR-008** records the decision, the documented downside (weaker last-gate review on a Haiku session), and the re-open condition (a hard release floor would justify pinning `opus`, but only as a recorded cost-policy decision).

## Test plan

- [x] `grep '^model:' agents/governance-reviewer.md` → `inherit` (root + `plugin/` mirror)
- [x] `bash tests/validate-plugin.sh --skip-install-check` → 139 PASS / 0 FAIL
- [x] ADR-008 present in `docs/adr/` and `plugin/docs/adr/`; `plugin/` mirror in sync
- [x] Version synced to 3.4.5 across all manifests + CHANGELOG

## Scope

**Claude Code-only** — Codex does not register plugin agents (its manifest is skills-only), so this has no effect on Codex users.