### PR TITLE
ci: gate release-qa + shellcheck in CI (v3.4.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "claude-governance",
       "description": "Governance framework with hooks (secret scanner, governance context), skills (/governance-check, /create-adr, /spec-driven-dev, /governance-setup), and agent (governance-reviewer)",
-      "version": "3.4.5",
+      "version": "3.4.6",
       "author": {
         "name": "pitimon"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "Complete governance framework for Claude Code — fitness functions, secret scanning, spec-driven development, ADR system, and Three Loops decision model",
   "author": {
     "name": "pitimon",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,3 +21,16 @@ jobs:
 
       - name: Run secret scanner tests
         run: bash tests/test-secret-scanner.sh
+
+      - name: Run release QA checks
+        run: bash tests/test-release-qa.sh
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: ShellCheck hooks and scripts
+        # The plugin's enforcement surface is shell. Gate on error+warning;
+        # info/style notes (e.g. intentional A && B || C idioms) do not fail CI.
+        run: shellcheck --severity=warning hooks/*.sh scripts/*.sh tests/*.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.6] - 2026-07-10
+
+CI hardening. The enforcement surface of this plugin is shell scripts, and one release gate ran only locally.
+
+### Added
+
+- `.github/workflows/validate.yml`: a **`shellcheck`** job (`--severity=warning`) over `hooks/`, `scripts/`, and `tests/` shell scripts — the plugin's enforcement layer is shell and had no lint gate. Info/style notes (intentional `A && B || C` idioms) do not fail CI.
+- CI now runs `tests/test-release-qa.sh` (166 checks). It was version-agnostic and passing since #40 but only enforced locally, despite the CHANGELOG treating it as part of the release ritual — now it is release-gating in fact.
+
+### Fixed
+
+- `tests/test-release-qa.sh` line 9: `cd "$REPO_ROOT"` → `cd "$REPO_ROOT" || exit 1` (SC2164 — the only shellcheck warning; a failed `cd` would otherwise run the whole suite in the wrong directory).
+- `README.md`: the file-tree comment for `test-release-qa.sh` said "local-only, not in CI" — corrected to "runs in CI" now that the workflow enforces it.
+
 ## [3.4.5] - 2026-07-10
 
 Resolves [#49](https://github.com/pitimon/claude-governance/issues/49). Claude Code-only (Codex does not register plugin agents).

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ claude-governance/
 ├── tests/
 │   ├── validate-plugin.sh       # Structural integrity (100+ checks in CI)
 │   ├── test-secret-scanner.sh   # 40 pattern-by-pattern tests
-│   └── test-release-qa.sh       # 166 QA checks (8-Habit verified; local-only, not in CI)
+│   └── test-release-qa.sh       # 166 QA checks (8-Habit verified; runs in CI)
 ├── .github/workflows/
 │   └── validate.yml             # CI: structural + scanner tests
 ├── CHANGELOG.md

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.6] - 2026-07-10
+
+CI hardening. The enforcement surface of this plugin is shell scripts, and one release gate ran only locally.
+
+### Added
+
+- `.github/workflows/validate.yml`: a **`shellcheck`** job (`--severity=warning`) over `hooks/`, `scripts/`, and `tests/` shell scripts — the plugin's enforcement layer is shell and had no lint gate. Info/style notes (intentional `A && B || C` idioms) do not fail CI.
+- CI now runs `tests/test-release-qa.sh` (166 checks). It was version-agnostic and passing since #40 but only enforced locally, despite the CHANGELOG treating it as part of the release ritual — now it is release-gating in fact.
+
+### Fixed
+
+- `tests/test-release-qa.sh` line 9: `cd "$REPO_ROOT"` → `cd "$REPO_ROOT" || exit 1` (SC2164 — the only shellcheck warning; a failed `cd` would otherwise run the whole suite in the wrong directory).
+- `README.md`: the file-tree comment for `test-release-qa.sh` said "local-only, not in CI" — corrected to "runs in CI" now that the workflow enforces it.
+
 ## [3.4.5] - 2026-07-10
 
 Resolves [#49](https://github.com/pitimon/claude-governance/issues/49). Claude Code-only (Codex does not register plugin agents).

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -401,7 +401,7 @@ claude-governance/
 ├── tests/
 │   ├── validate-plugin.sh       # Structural integrity (100+ checks in CI)
 │   ├── test-secret-scanner.sh   # 40 pattern-by-pattern tests
-│   └── test-release-qa.sh       # 166 QA checks (8-Habit verified; local-only, not in CI)
+│   └── test-release-qa.sh       # 166 QA checks (8-Habit verified; runs in CI)
 ├── .github/workflows/
 │   └── validate.yml             # CI: structural + scanner tests
 ├── CHANGELOG.md

--- a/tests/test-release-qa.sh
+++ b/tests/test-release-qa.sh
@@ -6,7 +6,7 @@
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-cd "$REPO_ROOT"
+cd "$REPO_ROOT" || exit 1
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
## Summary

- The plugin's enforcement surface is shell scripts, but CI ran **no linter** and did **not** run the release-QA suite. `tests/test-release-qa.sh` (166 checks) has been version-agnostic and passing since #40 and the CHANGELOG treats it as part of the release ritual, yet it was only enforced locally.
- **Added to `validate.yml`:** a `test-release-qa.sh` step + a `shellcheck` job (`--severity=warning` over `hooks/`, `scripts/`, `tests/`). Info/style notes (intentional `A && B || C` idioms) do not fail CI.
- **Fixed:** `test-release-qa.sh` `cd "$REPO_ROOT"` → `cd "$REPO_ROOT" || exit 1` (SC2164 — the only shellcheck warning). Corrected the README file-tree comment that claimed the suite is "local-only, not in CI".

No `|| true` / `continue-on-error` — gates fail loudly on findings (per the repo's "no false success report" rule).

## Test plan

- [x] `shellcheck --severity=warning hooks/*.sh scripts/*.sh tests/*.sh` → exit 0
- [x] `.github/workflows/validate.yml` parses as valid YAML; jobs = `validate`, `shellcheck`
- [x] `bash tests/test-release-qa.sh` → 166 PASS / 0 FAIL after the cd fix
- [x] `bash tests/validate-plugin.sh --skip-install-check` → 139 PASS / 0 FAIL
- [x] This PR's own CI run exercises both new gates

## Scope

CI + a shell-robustness fix + one README doc correction. `.github/` and `tests/` are not part of the `plugin/` mirror; README is mirrored and synced.