### PR TITLE
feat(hooks): PowerShell hook ports for native-Windows Claude Code (v3.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "claude-governance",
       "description": "Governance framework with hooks (secret scanner, governance context), skills (/governance-check, /create-adr, /spec-driven-dev, /governance-setup), and agent (governance-reviewer)",
-      "version": "3.4.6",
+      "version": "3.5.0",
       "author": {
         "name": "pitimon"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.6",
+  "version": "3.5.0",
   "description": "Complete governance framework for Claude Code — fitness functions, secret scanning, spec-driven development, ADR system, and Three Loops decision model",
   "author": {
     "name": "pitimon",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.6",
+  "version": "3.5.0",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,3 +34,23 @@ jobs:
         # The plugin's enforcement surface is shell. Gate on error+warning;
         # info/style notes (e.g. intentional A && B || C idioms) do not fail CI.
         run: shellcheck --severity=warning hooks/*.sh scripts/*.sh tests/*.sh
+
+  powershell-hooks:
+    # Verifies the PowerShell hook ports (for native-Windows without Git Bash)
+    # stay behaviourally identical to the bash hooks, on real Windows PowerShell.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Secret-scanner parity (shared fixtures)
+        shell: powershell
+        run: .\tests\test-secret-scanner.ps1
+
+      - name: session-start.ps1 emits valid JSON matching session-start.sh
+        shell: powershell
+        run: |
+          $ps = & .\hooks\session-start.ps1 | Out-String
+          $obj = $ps | ConvertFrom-Json   # throws if invalid JSON
+          if ($obj.hookSpecificOutput.hookEventName -ne 'SessionStart') { throw 'wrong hookEventName' }
+          if (-not $obj.hookSpecificOutput.additionalContext) { throw 'empty additionalContext' }
+          Write-Host 'session-start.ps1 JSON OK'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,7 +49,10 @@ jobs:
       - name: session-start.ps1 emits valid JSON matching session-start.sh
         shell: powershell
         run: |
-          $ps = & .\hooks\session-start.ps1 | Out-String
+          # Invoke as a child process so the hook's real stdout (written via
+          # [Console]::Out.Write, the stream Claude Code reads) is captured —
+          # a same-process `& .\script` would miss it. Strip a leading BOM.
+          $ps = (powershell -NoProfile -ExecutionPolicy Bypass -File .\hooks\session-start.ps1 | Out-String).TrimStart([char]0xFEFF)
           $obj = $ps | ConvertFrom-Json   # throws if invalid JSON
           if ($obj.hookSpecificOutput.hookEventName -ne 'SessionStart') { throw 'wrong hookEventName' }
           if (-not $obj.hookSpecificOutput.additionalContext) { throw 'empty additionalContext' }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ This is your install + operating protocol. Claude Code reads `./CLAUDE.md` autom
 
 Skills are guidance that an agent executes under the user's authority. Claude Code hooks provide local enforcement for Claude Code only. In Codex, use the skills as explicit checklists and workflows; do not assume `hooks/session-start.sh` or `hooks/secret-scanner.sh` are automatically active. Note that Codex still _parses_ `hooks/hooks.json` at install with a strict schema (top level = `hooks` only — see issue #51), so that file must stay schema-pure even though Codex does not run the hooks.
 
+PowerShell ports (`hooks/secret-scanner.ps1`, `hooks/session-start.ps1`) exist for Claude Code on native Windows without Git Bash; they are verified equivalent to the `.sh` hooks on a `windows-latest` CI job. Codex does not run them either. See the Platform Support table in `README.md`.
+
 ## Common tasks
 
 - **"Check this before commit"** -> `skills/governance-check/SKILL.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-07-10
+
+PowerShell hook ports for Claude Code on native Windows without Git Bash — where Claude Code falls back to the PowerShell shell tool and the `.sh` hooks cannot run, so the secret scanner would otherwise be silently absent. Claude Code-only (Codex does not run hooks). Scanner parity was verified on real Windows PowerShell 5.1 (38/38 shared fixtures) and is gated on a `windows-latest` CI job.
+
+### Added
+
+- `hooks/secret-scanner.ps1` — PowerShell port of `secret-scanner.sh`. Byte-for-byte behavioural parity: case-sensitive matching (`-cmatch`) and line-by-line scanning to mirror `grep -E`; the same 22 BLOCK + 3 two-stage DIGIT_REQUIRED + 3 WARN patterns; the same raw-scan fallback (never silent). Verified 38/38 against the shared fixtures on Windows PowerShell 5.1.
+- `hooks/session-start.ps1` — PowerShell port of `session-start.sh`, emitting the identical SessionStart JSON (UTF-8 with BOM so PS 5.1 renders the unicode arrows/em-dashes correctly).
+- `tests/fixtures/scanner-cases.jsonl` — shared scanner fixtures (payload + expected outcome) consumed by the Windows parity test; the bash suite is checked against the same set so `.ps1` and `.sh` cannot drift.
+- `tests/test-secret-scanner.ps1` — Windows-side parity runner over the shared fixtures.
+- `.github/workflows/validate.yml`: a `powershell-hooks` job on `windows-latest` running the parity test + a `session-start.ps1` JSON-validity check.
+
+### Notes
+
+- **Auto-dispatch is intentionally not wired into `hooks/hooks.json`.** Claude Code exposes one hook `command` per event with no OS switch; selecting `.ps1` vs `.sh` per-OS without breaking macOS/Linux (or emitting per-edit errors there) needs a mechanism only confirmable on a real Windows + Claude Code install. The `.ps1` hooks ship now (proven on Windows) and can be wired manually; full auto-dispatch is tracked in [#58](https://github.com/pitimon/claude-governance/issues/58). See the Platform Support table in `README.md`.
+
 ## [3.4.6] - 2026-07-10
 
 CI hardening. The enforcement surface of this plugin is shell scripts, and one release gate ran only locally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ hooks/
   hooks.json             # Hook registrations (SessionStart, PreToolUse)
   session-start.sh       # Governance context injection (~300 tokens per session)
   secret-scanner.sh      # Blocks file writes containing hardcoded secrets
+  session-start.ps1      # PowerShell port of session-start.sh (native Windows, no Git Bash)
+  secret-scanner.ps1     # PowerShell port of secret-scanner.sh (parity-tested on Windows CI)
 skills/
   spec-driven-dev/SKILL.md    # /spec-driven-dev — spec-first development workflow
   governance-check/SKILL.md   # /governance-check — fitness function runner

--- a/README.md
+++ b/README.md
@@ -335,6 +335,23 @@ Understand ──> Specify ──> Plan ──> Implement ──> Verify
 
 ---
 
+## Platform Support
+
+Skills, ADRs, and compliance docs are plain Markdown and work identically everywhere. The **hooks** (SessionStart context + PreToolUse secret scanner) are the only platform-sensitive surface:
+
+| Environment | Hook behaviour |
+| --- | --- |
+| macOS / Linux | `.sh` hooks run via bash (default) |
+| Windows **with** Git for Windows | `.sh` hooks run via Git Bash (Claude Code's default shell there) |
+| Windows **without** Git Bash | Claude Code falls back to the PowerShell shell tool; `.sh` hooks cannot run. PowerShell ports — `hooks/secret-scanner.ps1`, `hooks/session-start.ps1` — are provided and verified byte-for-byte equivalent to the bash hooks (parity gated on a `windows-latest` CI job). |
+| **Codex** (any OS) | Does not run hooks at all — skills are used as explicit checklists. |
+
+> **Native-Windows auto-dispatch is not yet wired into the default `hooks/hooks.json`.** Claude Code exposes a single hook `command` per event with no OS switch, and selecting the right script per-OS without breaking macOS/Linux users (or spamming them with per-edit errors) needs a mechanism that can only be confirmed on a real Windows + Claude Code install. That validation is tracked in **[#58](https://github.com/pitimon/claude-governance/issues/58)**. The `.ps1` hooks ship now (proven on Windows PowerShell 5.1) so the port is ready the moment dispatch is confirmed; a technical user can also wire them manually via a personal `settings.json` PreToolUse/SessionStart hook that runs `powershell -NoProfile -ExecutionPolicy Bypass -File <path>` (Windows PowerShell requires `-ExecutionPolicy Bypass` under the default Restricted policy).
+
+**Requirement for the PowerShell path:** Windows 10 1809+ with Windows PowerShell 5.1 (included by default).
+
+---
+
 ## Token Budget
 
 | Component            | Tokens   | When                        |

--- a/hooks/secret-scanner.ps1
+++ b/hooks/secret-scanner.ps1
@@ -1,0 +1,162 @@
+#Requires -Version 5.1
+# secret-scanner.ps1 - PowerShell port of secret-scanner.sh
+# Runs as PreToolUse hook on Edit|Write|MultiEdit for Claude Code on native
+# Windows without Git Bash (where the shell tool falls back to PowerShell).
+# Exit 0 = allow (or warn for PII), Exit 2 = block (secrets/credentials).
+#
+# Parity contract with secret-scanner.sh:
+#   - Case-SENSITIVE matching (-cmatch / [regex] default) to mirror grep -E.
+#   - Line-by-line matching to mirror grep's per-line semantics (so ^ anchors
+#     behave the same as in the bash version).
+#   - Same two-stage DIGIT_REQUIRED check and same raw-scan fallback.
+
+$ErrorActionPreference = 'Stop'
+
+# Read the hook payload from stdin. ($input is a reserved automatic variable in
+# PowerShell - never shadow it; this script uses $payload.)
+$payload = [Console]::In.ReadToEnd()
+
+# Parse tool_name via JSON (whitespace-agnostic - the fail-open the .sh grep had
+# cannot occur here). Fall back to empty on any parse failure.
+$toolName = ''
+$obj = $null
+try {
+  $obj = $payload | ConvertFrom-Json
+  if ($null -ne $obj.tool_name) { $toolName = [string]$obj.tool_name }
+} catch {
+  $toolName = ''
+}
+
+$content = ''
+$recognized = $true
+switch ($toolName) {
+  'Write'     { try { $content = [string]$obj.tool_input.content } catch { $content = '' } }
+  'Edit'      { try { $content = [string]$obj.tool_input.new_string } catch { $content = '' } }
+  'MultiEdit' {
+    try { $content = (($obj.tool_input.edits | ForEach-Object { [string]$_.new_string }) -join ' ') }
+    catch { $content = '' }
+  }
+  default     { $recognized = $false }
+}
+
+# Fail-safe: never silently allow. If content extraction produced nothing -
+# unparseable/unexpected tool_name, or a changed tool_input shape - scan the RAW
+# payload so a secret cannot slip through on a payload we failed to parse. Only
+# an unrecognized/unparseable tool warns, so a legitimate empty write is quiet.
+$fellBack = $false
+if ([string]::IsNullOrEmpty($content)) {
+  $content = $payload
+  if (-not $recognized) { $fellBack = $true }
+}
+
+# Quote chars, composed so this source file contains no bare quote-in-class that
+# a naive scanner would trip over.
+$q  = [char]0x27   # single quote
+$dq = [char]0x22   # double quote
+
+# --- Matching helpers (case-sensitive, line-by-line to mirror grep -E) ---
+function Test-BlockPattern([string]$text, [string]$pattern) {
+  foreach ($line in ($text -split "`n")) {
+    if ($line -cmatch $pattern) { return $true }
+  }
+  return $false
+}
+
+function Write-BlockMessage([string]$desc) {
+  [Console]::Error.WriteLine("Governance: Blocked - $desc detected in file content.")
+  [Console]::Error.WriteLine("")
+  [Console]::Error.WriteLine("Use environment variables instead of hardcoding secrets:")
+  [Console]::Error.WriteLine("  JS/TS:  const value = process.env.YOUR_SECRET")
+  [Console]::Error.WriteLine("  Python: value = os.environ[${q}YOUR_SECRET${q}]")
+  [Console]::Error.WriteLine("  Go:     value := os.Getenv(${dq}YOUR_SECRET${dq})")
+  [Console]::Error.WriteLine("")
+  [Console]::Error.WriteLine("To fix: replace the hardcoded value with an environment variable reference.")
+}
+
+# === BLOCK PATTERNS (exit 2) - secrets and credentials ===
+# [pattern, description]. Quote classes built from $dq/$q so the regex reaches
+# the .NET engine as ["'] and [^'"].
+$blockPatterns = @(
+  @("API_KEY\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded API key'),
+  @("api_key\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded API key'),
+  @("password\s*=\s*[$dq$q][^$q$dq]{4,}[$dq$q]", 'Hardcoded password'),
+  @("PASSWORD\s*=\s*[$dq$q][^$q$dq]{4,}[$dq$q]", 'Hardcoded password'),
+  @("ghp_[A-Za-z0-9]{36,}", 'GitHub personal access token'),
+  @("gho_[A-Za-z0-9]{36,}", 'GitHub OAuth token'),
+  @("ghs_[A-Za-z0-9]{36,}", 'GitHub server token'),
+  @("AKIA[A-Z0-9]{16}", 'AWS access key ID'),
+  @("xox[bpsar]-[A-Za-z0-9\-]{10,}", 'Slack token'),
+  @("-----BEGIN[A-Z ]*PRIVATE KEY-----", 'Private key block'),
+  @("eyJ[A-Za-z0-9_-]{15,}\.[A-Za-z0-9_-]{15,}", 'JWT token'),
+  @("AIza[0-9A-Za-z_-]{35}", 'Google API key'),
+  @("DefaultEndpointsProtocol=https;AccountName=", 'Azure connection string'),
+  @("mongodb(\+srv)?://[^\s]+", 'MongoDB connection string'),
+  @("[Tt]oken\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded token'),
+  @("GITHUB_TOKEN\s*=\s*[$dq$q][^$q$dq]{4,}[$dq$q]", 'GitHub token assignment'),
+  @("GH_TOKEN\s*=\s*[$dq$q][^$q$dq]{4,}[$dq$q]", 'GitHub token assignment'),
+  @("Bearer\s+[A-Za-z0-9_\-\.]{20,}", 'Bearer token in code'),
+  @("Authorization:\s*Bearer\s+[A-Za-z0-9_\-\.]{20,}", 'Hardcoded Authorization header'),
+  @("oauth_token\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded OAuth token'),
+  @("refresh_token\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded refresh token'),
+  @("client_secret\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded client secret')
+)
+
+foreach ($entry in $blockPatterns) {
+  if (Test-BlockPattern $content $entry[0]) {
+    Write-BlockMessage $entry[1]
+    exit 2
+  }
+}
+
+# === DIGIT-REQUIRED BLOCK PATTERNS (exit 2) - sk-shaped keys (issue #29) ===
+# Two-stage: (1) base regex must match with a left boundary that rejects a
+# preceding letter (the NIST AI ...risk-management slug); (2) the matched text
+# must contain at least one digit.
+$digitRequiredPatterns = @(
+  @("(^|[^A-Za-z])sk-[A-Za-z0-9_-]{20,}", 'OpenAI/Stripe secret key'),
+  @("(^|[^A-Za-z])sk-proj-[A-Za-z0-9_-]{20,}", 'OpenAI project key'),
+  @("(^|[^A-Za-z])sk-ant-[A-Za-z0-9_-]{20,}", 'Anthropic API key')
+)
+
+foreach ($entry in $digitRequiredPatterns) {
+  $matched = $false
+  foreach ($line in ($content -split "`n")) {
+    foreach ($m in [regex]::Matches($line, $entry[0])) {
+      if ($m.Value -cmatch '[0-9]') { $matched = $true; break }
+    }
+    if ($matched) { break }
+  }
+  if ($matched) {
+    Write-BlockMessage $entry[1]
+    exit 2
+  }
+}
+
+# === WARN PATTERNS (exit 0 + stderr) - PII detection [DSGAI01] ===
+$warnPatterns = @(
+  @("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", 'Possible email address (PII)'),
+  @("\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b", 'Possible SSN (PII)'),
+  @("\b[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}\b", 'Possible credit card number (PII)')
+)
+
+$piiWarned = $false
+foreach ($entry in $warnPatterns) {
+  if (Test-BlockPattern $content $entry[0]) {
+    [Console]::Error.WriteLine("Governance: WARNING - $($entry[1]). Review before committing.")
+    $piiWarned = $true
+  }
+}
+
+if ($piiWarned) {
+  [Console]::Error.WriteLine("")
+  [Console]::Error.WriteLine("PII detected. Ensure data handling complies with your data classification policy.")
+  [Console]::Error.WriteLine("See: examples/DATA-CLASSIFICATION.md.example for guidance. [DSGAI01]")
+}
+
+# Surface a parse-failure fallback (never silent).
+if ($fellBack) {
+  $tn = if ([string]::IsNullOrEmpty($toolName)) { '<empty>' } else { $toolName }
+  [Console]::Error.WriteLine("Governance: WARNING - could not parse tool payload (tool_name='$tn'); scanned raw input as a fallback, no secret found. If this recurs, the hook JSON parsing may need updating.")
+}
+
+exit 0

--- a/hooks/session-start.ps1
+++ b/hooks/session-start.ps1
@@ -1,0 +1,17 @@
+﻿#Requires -Version 5.1
+# session-start.ps1 - PowerShell port of session-start.sh (SessionStart hook).
+# Emits the identical governance-context JSON to stdout. File is UTF-8 WITH BOM
+# so Windows PowerShell 5.1 reads the unicode arrows/em-dashes correctly (it
+# otherwise decodes .ps1 source as ANSI); output encoding is set to UTF-8 too.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$json = @'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "## Governance Framework Active\n\nYou have the **claude-governance** plugin installed. Follow these governance principles:\n\n### Three Loops Decision Model\n- **Out-of-Loop** (AI autonomous): Formatting, lint fixes, import cleanup, simple bug fixes\n- **On-the-Loop** (AI proposes, human approves): New features, API changes, refactoring >3 files\n- **In-the-Loop** (Human decides): Architecture, security model, breaking changes, data migration\n\n**Consequence Override**: Irreversible operations (production deploy, data deletion, credential rotation) → always In-the-Loop regardless of task type. See ADR-002.\n\n### Pre-Commit Fitness Functions\nBefore committing, self-check:\n- No hardcoded secrets (API_KEY=, password=, sk-, sk-ant-, ghp_, AKIA, token=, private keys, JWT)\n- No hardcoded agent credentials (OAuth, bearer, refresh tokens, client secrets) [DSGAI02]\n- Input validation on all new endpoints (language-appropriate: Zod/joi for JS, pydantic for Python, go-validator for Go, serde for Rust)\n- Parameterized database queries (no string interpolation)\n- File size < 800 lines, functions < 50 lines\n- Immutable patterns (no mutation of shared state)\n- No debug prints in production code (console.log, print(), fmt.Println, println!)\n- Context minimization: no unnecessary sensitive data in prompts, rules, or CLAUDE.md [DSGAI15]\n\n### Quality Standards\n- Conventional commits: feat, fix, refactor, docs, test, chore, perf, ci\n- Test coverage >= 80% for changed files\n- Error messages must not leak internal details\n- DOMAIN.md updated if entity schema changed\n\n### Available Commands\n- `/governance-check [pre-commit|pre-pr|architecture|all]` — Quick fitness function checklist (fast, single-category, pass/fail)\n- `/create-adr <title>` — Create Architecture Decision Record\n- `/spec-driven-dev` — Spec-first development workflow\n- `/governance-setup` — Initialize governance in a project\n- `/eu-ai-act-check` — EU AI Act Arts 9-15 readiness checklist (high-risk AI systems)\n- `/iso-42001-check` — ISO/IEC 42001:2023 AIMS readiness checklist (38 controls)\n- `governance-reviewer` agent — Deep multi-file compliance review (severity-graded, domain invariants, architecture)\n- `docs/compliance/DSGAI-MAPPING.md` — OWASP DSGAI control mapping (11 controls)"
+  }
+}
+'@
+[Console]::Out.Write($json)
+[Console]::Out.Write("`n")
+exit 0

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-governance",
-  "version": "3.4.6",
+  "version": "3.5.0",
   "description": "Governance framework for AI-assisted development: fitness checks, ADRs, spec-driven development, and compliance checklists.",
   "author": {
     "name": "pitimon",

--- a/plugin/AGENTS.md
+++ b/plugin/AGENTS.md
@@ -23,6 +23,8 @@ This is your install + operating protocol. Claude Code reads `./CLAUDE.md` autom
 
 Skills are guidance that an agent executes under the user's authority. Claude Code hooks provide local enforcement for Claude Code only. In Codex, use the skills as explicit checklists and workflows; do not assume `hooks/session-start.sh` or `hooks/secret-scanner.sh` are automatically active. Note that Codex still _parses_ `hooks/hooks.json` at install with a strict schema (top level = `hooks` only — see issue #51), so that file must stay schema-pure even though Codex does not run the hooks.
 
+PowerShell ports (`hooks/secret-scanner.ps1`, `hooks/session-start.ps1`) exist for Claude Code on native Windows without Git Bash; they are verified equivalent to the `.sh` hooks on a `windows-latest` CI job. Codex does not run them either. See the Platform Support table in `README.md`.
+
 ## Common tasks
 
 - **"Check this before commit"** -> `skills/governance-check/SKILL.md`

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-07-10
+
+PowerShell hook ports for Claude Code on native Windows without Git Bash — where Claude Code falls back to the PowerShell shell tool and the `.sh` hooks cannot run, so the secret scanner would otherwise be silently absent. Claude Code-only (Codex does not run hooks). Scanner parity was verified on real Windows PowerShell 5.1 (38/38 shared fixtures) and is gated on a `windows-latest` CI job.
+
+### Added
+
+- `hooks/secret-scanner.ps1` — PowerShell port of `secret-scanner.sh`. Byte-for-byte behavioural parity: case-sensitive matching (`-cmatch`) and line-by-line scanning to mirror `grep -E`; the same 22 BLOCK + 3 two-stage DIGIT_REQUIRED + 3 WARN patterns; the same raw-scan fallback (never silent). Verified 38/38 against the shared fixtures on Windows PowerShell 5.1.
+- `hooks/session-start.ps1` — PowerShell port of `session-start.sh`, emitting the identical SessionStart JSON (UTF-8 with BOM so PS 5.1 renders the unicode arrows/em-dashes correctly).
+- `tests/fixtures/scanner-cases.jsonl` — shared scanner fixtures (payload + expected outcome) consumed by the Windows parity test; the bash suite is checked against the same set so `.ps1` and `.sh` cannot drift.
+- `tests/test-secret-scanner.ps1` — Windows-side parity runner over the shared fixtures.
+- `.github/workflows/validate.yml`: a `powershell-hooks` job on `windows-latest` running the parity test + a `session-start.ps1` JSON-validity check.
+
+### Notes
+
+- **Auto-dispatch is intentionally not wired into `hooks/hooks.json`.** Claude Code exposes one hook `command` per event with no OS switch; selecting `.ps1` vs `.sh` per-OS without breaking macOS/Linux (or emitting per-edit errors there) needs a mechanism only confirmable on a real Windows + Claude Code install. The `.ps1` hooks ship now (proven on Windows) and can be wired manually; full auto-dispatch is tracked in [#58](https://github.com/pitimon/claude-governance/issues/58). See the Platform Support table in `README.md`.
+
 ## [3.4.6] - 2026-07-10
 
 CI hardening. The enforcement surface of this plugin is shell scripts, and one release gate ran only locally.

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -24,6 +24,8 @@ hooks/
   hooks.json             # Hook registrations (SessionStart, PreToolUse)
   session-start.sh       # Governance context injection (~300 tokens per session)
   secret-scanner.sh      # Blocks file writes containing hardcoded secrets
+  session-start.ps1      # PowerShell port of session-start.sh (native Windows, no Git Bash)
+  secret-scanner.ps1     # PowerShell port of secret-scanner.sh (parity-tested on Windows CI)
 skills/
   spec-driven-dev/SKILL.md    # /spec-driven-dev — spec-first development workflow
   governance-check/SKILL.md   # /governance-check — fitness function runner

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -335,6 +335,23 @@ Understand ──> Specify ──> Plan ──> Implement ──> Verify
 
 ---
 
+## Platform Support
+
+Skills, ADRs, and compliance docs are plain Markdown and work identically everywhere. The **hooks** (SessionStart context + PreToolUse secret scanner) are the only platform-sensitive surface:
+
+| Environment | Hook behaviour |
+| --- | --- |
+| macOS / Linux | `.sh` hooks run via bash (default) |
+| Windows **with** Git for Windows | `.sh` hooks run via Git Bash (Claude Code's default shell there) |
+| Windows **without** Git Bash | Claude Code falls back to the PowerShell shell tool; `.sh` hooks cannot run. PowerShell ports — `hooks/secret-scanner.ps1`, `hooks/session-start.ps1` — are provided and verified byte-for-byte equivalent to the bash hooks (parity gated on a `windows-latest` CI job). |
+| **Codex** (any OS) | Does not run hooks at all — skills are used as explicit checklists. |
+
+> **Native-Windows auto-dispatch is not yet wired into the default `hooks/hooks.json`.** Claude Code exposes a single hook `command` per event with no OS switch, and selecting the right script per-OS without breaking macOS/Linux users (or spamming them with per-edit errors) needs a mechanism that can only be confirmed on a real Windows + Claude Code install. That validation is tracked in **[#58](https://github.com/pitimon/claude-governance/issues/58)**. The `.ps1` hooks ship now (proven on Windows PowerShell 5.1) so the port is ready the moment dispatch is confirmed; a technical user can also wire them manually via a personal `settings.json` PreToolUse/SessionStart hook that runs `powershell -NoProfile -ExecutionPolicy Bypass -File <path>` (Windows PowerShell requires `-ExecutionPolicy Bypass` under the default Restricted policy).
+
+**Requirement for the PowerShell path:** Windows 10 1809+ with Windows PowerShell 5.1 (included by default).
+
+---
+
 ## Token Budget
 
 | Component            | Tokens   | When                        |

--- a/plugin/hooks/secret-scanner.ps1
+++ b/plugin/hooks/secret-scanner.ps1
@@ -1,0 +1,162 @@
+#Requires -Version 5.1
+# secret-scanner.ps1 - PowerShell port of secret-scanner.sh
+# Runs as PreToolUse hook on Edit|Write|MultiEdit for Claude Code on native
+# Windows without Git Bash (where the shell tool falls back to PowerShell).
+# Exit 0 = allow (or warn for PII), Exit 2 = block (secrets/credentials).
+#
+# Parity contract with secret-scanner.sh:
+#   - Case-SENSITIVE matching (-cmatch / [regex] default) to mirror grep -E.
+#   - Line-by-line matching to mirror grep's per-line semantics (so ^ anchors
+#     behave the same as in the bash version).
+#   - Same two-stage DIGIT_REQUIRED check and same raw-scan fallback.
+
+$ErrorActionPreference = 'Stop'
+
+# Read the hook payload from stdin. ($input is a reserved automatic variable in
+# PowerShell - never shadow it; this script uses $payload.)
+$payload = [Console]::In.ReadToEnd()
+
+# Parse tool_name via JSON (whitespace-agnostic - the fail-open the .sh grep had
+# cannot occur here). Fall back to empty on any parse failure.
+$toolName = ''
+$obj = $null
+try {
+  $obj = $payload | ConvertFrom-Json
+  if ($null -ne $obj.tool_name) { $toolName = [string]$obj.tool_name }
+} catch {
+  $toolName = ''
+}
+
+$content = ''
+$recognized = $true
+switch ($toolName) {
+  'Write'     { try { $content = [string]$obj.tool_input.content } catch { $content = '' } }
+  'Edit'      { try { $content = [string]$obj.tool_input.new_string } catch { $content = '' } }
+  'MultiEdit' {
+    try { $content = (($obj.tool_input.edits | ForEach-Object { [string]$_.new_string }) -join ' ') }
+    catch { $content = '' }
+  }
+  default     { $recognized = $false }
+}
+
+# Fail-safe: never silently allow. If content extraction produced nothing -
+# unparseable/unexpected tool_name, or a changed tool_input shape - scan the RAW
+# payload so a secret cannot slip through on a payload we failed to parse. Only
+# an unrecognized/unparseable tool warns, so a legitimate empty write is quiet.
+$fellBack = $false
+if ([string]::IsNullOrEmpty($content)) {
+  $content = $payload
+  if (-not $recognized) { $fellBack = $true }
+}
+
+# Quote chars, composed so this source file contains no bare quote-in-class that
+# a naive scanner would trip over.
+$q  = [char]0x27   # single quote
+$dq = [char]0x22   # double quote
+
+# --- Matching helpers (case-sensitive, line-by-line to mirror grep -E) ---
+function Test-BlockPattern([string]$text, [string]$pattern) {
+  foreach ($line in ($text -split "`n")) {
+    if ($line -cmatch $pattern) { return $true }
+  }
+  return $false
+}
+
+function Write-BlockMessage([string]$desc) {
+  [Console]::Error.WriteLine("Governance: Blocked - $desc detected in file content.")
+  [Console]::Error.WriteLine("")
+  [Console]::Error.WriteLine("Use environment variables instead of hardcoding secrets:")
+  [Console]::Error.WriteLine("  JS/TS:  const value = process.env.YOUR_SECRET")
+  [Console]::Error.WriteLine("  Python: value = os.environ[${q}YOUR_SECRET${q}]")
+  [Console]::Error.WriteLine("  Go:     value := os.Getenv(${dq}YOUR_SECRET${dq})")
+  [Console]::Error.WriteLine("")
+  [Console]::Error.WriteLine("To fix: replace the hardcoded value with an environment variable reference.")
+}
+
+# === BLOCK PATTERNS (exit 2) - secrets and credentials ===
+# [pattern, description]. Quote classes built from $dq/$q so the regex reaches
+# the .NET engine as ["'] and [^'"].
+$blockPatterns = @(
+  @("API_KEY\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded API key'),
+  @("api_key\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded API key'),
+  @("password\s*=\s*[$dq$q][^$q$dq]{4,}[$dq$q]", 'Hardcoded password'),
+  @("PASSWORD\s*=\s*[$dq$q][^$q$dq]{4,}[$dq$q]", 'Hardcoded password'),
+  @("ghp_[A-Za-z0-9]{36,}", 'GitHub personal access token'),
+  @("gho_[A-Za-z0-9]{36,}", 'GitHub OAuth token'),
+  @("ghs_[A-Za-z0-9]{36,}", 'GitHub server token'),
+  @("AKIA[A-Z0-9]{16}", 'AWS access key ID'),
+  @("xox[bpsar]-[A-Za-z0-9\-]{10,}", 'Slack token'),
+  @("-----BEGIN[A-Z ]*PRIVATE KEY-----", 'Private key block'),
+  @("eyJ[A-Za-z0-9_-]{15,}\.[A-Za-z0-9_-]{15,}", 'JWT token'),
+  @("AIza[0-9A-Za-z_-]{35}", 'Google API key'),
+  @("DefaultEndpointsProtocol=https;AccountName=", 'Azure connection string'),
+  @("mongodb(\+srv)?://[^\s]+", 'MongoDB connection string'),
+  @("[Tt]oken\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded token'),
+  @("GITHUB_TOKEN\s*=\s*[$dq$q][^$q$dq]{4,}[$dq$q]", 'GitHub token assignment'),
+  @("GH_TOKEN\s*=\s*[$dq$q][^$q$dq]{4,}[$dq$q]", 'GitHub token assignment'),
+  @("Bearer\s+[A-Za-z0-9_\-\.]{20,}", 'Bearer token in code'),
+  @("Authorization:\s*Bearer\s+[A-Za-z0-9_\-\.]{20,}", 'Hardcoded Authorization header'),
+  @("oauth_token\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded OAuth token'),
+  @("refresh_token\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded refresh token'),
+  @("client_secret\s*=\s*[$dq$q][A-Za-z0-9_\-]{10,}[$dq$q]", 'Hardcoded client secret')
+)
+
+foreach ($entry in $blockPatterns) {
+  if (Test-BlockPattern $content $entry[0]) {
+    Write-BlockMessage $entry[1]
+    exit 2
+  }
+}
+
+# === DIGIT-REQUIRED BLOCK PATTERNS (exit 2) - sk-shaped keys (issue #29) ===
+# Two-stage: (1) base regex must match with a left boundary that rejects a
+# preceding letter (the NIST AI ...risk-management slug); (2) the matched text
+# must contain at least one digit.
+$digitRequiredPatterns = @(
+  @("(^|[^A-Za-z])sk-[A-Za-z0-9_-]{20,}", 'OpenAI/Stripe secret key'),
+  @("(^|[^A-Za-z])sk-proj-[A-Za-z0-9_-]{20,}", 'OpenAI project key'),
+  @("(^|[^A-Za-z])sk-ant-[A-Za-z0-9_-]{20,}", 'Anthropic API key')
+)
+
+foreach ($entry in $digitRequiredPatterns) {
+  $matched = $false
+  foreach ($line in ($content -split "`n")) {
+    foreach ($m in [regex]::Matches($line, $entry[0])) {
+      if ($m.Value -cmatch '[0-9]') { $matched = $true; break }
+    }
+    if ($matched) { break }
+  }
+  if ($matched) {
+    Write-BlockMessage $entry[1]
+    exit 2
+  }
+}
+
+# === WARN PATTERNS (exit 0 + stderr) - PII detection [DSGAI01] ===
+$warnPatterns = @(
+  @("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", 'Possible email address (PII)'),
+  @("\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b", 'Possible SSN (PII)'),
+  @("\b[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}\b", 'Possible credit card number (PII)')
+)
+
+$piiWarned = $false
+foreach ($entry in $warnPatterns) {
+  if (Test-BlockPattern $content $entry[0]) {
+    [Console]::Error.WriteLine("Governance: WARNING - $($entry[1]). Review before committing.")
+    $piiWarned = $true
+  }
+}
+
+if ($piiWarned) {
+  [Console]::Error.WriteLine("")
+  [Console]::Error.WriteLine("PII detected. Ensure data handling complies with your data classification policy.")
+  [Console]::Error.WriteLine("See: examples/DATA-CLASSIFICATION.md.example for guidance. [DSGAI01]")
+}
+
+# Surface a parse-failure fallback (never silent).
+if ($fellBack) {
+  $tn = if ([string]::IsNullOrEmpty($toolName)) { '<empty>' } else { $toolName }
+  [Console]::Error.WriteLine("Governance: WARNING - could not parse tool payload (tool_name='$tn'); scanned raw input as a fallback, no secret found. If this recurs, the hook JSON parsing may need updating.")
+}
+
+exit 0

--- a/plugin/hooks/session-start.ps1
+++ b/plugin/hooks/session-start.ps1
@@ -1,0 +1,17 @@
+﻿#Requires -Version 5.1
+# session-start.ps1 - PowerShell port of session-start.sh (SessionStart hook).
+# Emits the identical governance-context JSON to stdout. File is UTF-8 WITH BOM
+# so Windows PowerShell 5.1 reads the unicode arrows/em-dashes correctly (it
+# otherwise decodes .ps1 source as ANSI); output encoding is set to UTF-8 too.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$json = @'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "## Governance Framework Active\n\nYou have the **claude-governance** plugin installed. Follow these governance principles:\n\n### Three Loops Decision Model\n- **Out-of-Loop** (AI autonomous): Formatting, lint fixes, import cleanup, simple bug fixes\n- **On-the-Loop** (AI proposes, human approves): New features, API changes, refactoring >3 files\n- **In-the-Loop** (Human decides): Architecture, security model, breaking changes, data migration\n\n**Consequence Override**: Irreversible operations (production deploy, data deletion, credential rotation) → always In-the-Loop regardless of task type. See ADR-002.\n\n### Pre-Commit Fitness Functions\nBefore committing, self-check:\n- No hardcoded secrets (API_KEY=, password=, sk-, sk-ant-, ghp_, AKIA, token=, private keys, JWT)\n- No hardcoded agent credentials (OAuth, bearer, refresh tokens, client secrets) [DSGAI02]\n- Input validation on all new endpoints (language-appropriate: Zod/joi for JS, pydantic for Python, go-validator for Go, serde for Rust)\n- Parameterized database queries (no string interpolation)\n- File size < 800 lines, functions < 50 lines\n- Immutable patterns (no mutation of shared state)\n- No debug prints in production code (console.log, print(), fmt.Println, println!)\n- Context minimization: no unnecessary sensitive data in prompts, rules, or CLAUDE.md [DSGAI15]\n\n### Quality Standards\n- Conventional commits: feat, fix, refactor, docs, test, chore, perf, ci\n- Test coverage >= 80% for changed files\n- Error messages must not leak internal details\n- DOMAIN.md updated if entity schema changed\n\n### Available Commands\n- `/governance-check [pre-commit|pre-pr|architecture|all]` — Quick fitness function checklist (fast, single-category, pass/fail)\n- `/create-adr <title>` — Create Architecture Decision Record\n- `/spec-driven-dev` — Spec-first development workflow\n- `/governance-setup` — Initialize governance in a project\n- `/eu-ai-act-check` — EU AI Act Arts 9-15 readiness checklist (high-risk AI systems)\n- `/iso-42001-check` — ISO/IEC 42001:2023 AIMS readiness checklist (38 controls)\n- `governance-reviewer` agent — Deep multi-file compliance review (severity-graded, domain invariants, architecture)\n- `docs/compliance/DSGAI-MAPPING.md` — OWASP DSGAI control mapping (11 controls)"
+  }
+}
+'@
+[Console]::Out.Write($json)
+[Console]::Out.Write("`n")
+exit 0

--- a/tests/fixtures/scanner-cases.jsonl
+++ b/tests/fixtures/scanner-cases.jsonl
@@ -1,0 +1,38 @@
+{"id": "api_key", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"API_KEY = \\\"abcdefghij1234567890\\\"\"}}", "expect": "block"}
+{"id": "password", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"password = \\\"mysecret\\\"\"}}", "expect": "block"}
+{"id": "sk_openai", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"sk-abc123def456ghi789jkl012\"}}", "expect": "block"}
+{"id": "sk_proj", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"sk-proj-abc123def456ghi789jkl012\"}}", "expect": "block"}
+{"id": "sk_ant", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"sk-ant-api03-abcdefghijklmnopqrst9\"}}", "expect": "block"}
+{"id": "ghp", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"ghp_abcdefghijklmnopqrstuvwxyz1234567890\"}}", "expect": "block"}
+{"id": "gho", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"gho_abcdefghijklmnopqrstuvwxyz1234567890\"}}", "expect": "block"}
+{"id": "ghs", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"ghs_abcdefghijklmnopqrstuvwxyz1234567890\"}}", "expect": "block"}
+{"id": "akia", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"AKIAIOSFODNN7EXAMPLE\"}}", "expect": "block"}
+{"id": "slack", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"xoxb-123456789-abcdefghij\"}}", "expect": "block"}
+{"id": "privkey", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"-----BEGIN RSA PRIVATE KEY-----\"}}", "expect": "block"}
+{"id": "jwt", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkw\"}}", "expect": "block"}
+{"id": "google", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"AIzaSyA1234567890abcdefghijklmnopqrstuv\"}}", "expect": "block"}
+{"id": "azure", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"DefaultEndpointsProtocol=https;AccountName=myaccount\"}}", "expect": "block"}
+{"id": "mongo", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"mongodb+srv://user:pass@cluster.mongodb.net\"}}", "expect": "block"}
+{"id": "token", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"Token = \\\"abc123def456xyz\\\"\"}}", "expect": "block"}
+{"id": "github_token", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"GITHUB_TOKEN = \\\"ghp_xxxxx\\\"\"}}", "expect": "block"}
+{"id": "gh_token", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"GH_TOKEN = \\\"ghp_xxxxx\\\"\"}}", "expect": "block"}
+{"id": "bearer", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9xxxx\"}}", "expect": "block"}
+{"id": "plain", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"Hello world\"}}", "expect": "allow"}
+{"id": "envref", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"const key = process.env.API_KEY\"}}", "expect": "allow"}
+{"id": "short", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"x = 42\"}}", "expect": "allow"}
+{"id": "comment_sk", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"# sk- prefix is used for API keys\"}}", "expect": "allow"}
+{"id": "auth_prose", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"# Doc mentions the Authorization header\"}}", "expect": "allow"}
+{"id": "db_prose", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"We use mongodb as our document store.\"}}", "expect": "allow"}
+{"id": "nist_slug", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"see nist.gov/itl/ai-risk-management-framework for details\"}}", "expect": "allow"}
+{"id": "sk_short", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"the value sk-9 is too short to be a key\"}}", "expect": "allow"}
+{"id": "sk_noletdigit", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"sk-aaaaaaaaaaaaaaaaaaaa is letters only\"}}", "expect": "allow"}
+{"id": "email", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"contact me at john.doe@example.com please\"}}", "expect": "warn"}
+{"id": "ssn", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"ssn 123-45-6789 here\"}}", "expect": "warn"}
+{"id": "cc", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"card 4111 1111 1111 1111 here\"}}", "expect": "warn"}
+{"id": "read_tool", "payload": "{\"tool_name\": \"Read\", \"tool_input\": {\"file_path\": \"/tmp/x\"}}", "expect": "warn"}
+{"id": "edit_secret", "payload": "{\"tool_name\": \"Edit\", \"tool_input\": {\"file_path\": \"/tmp/x\", \"old_string\": \"x\", \"new_string\": \"sk-ant-api03-abcdefghijklmnopqrst9\"}}", "expect": "block"}
+{"id": "empty", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"\"}}", "expect": "allow"}
+{"id": "spaced_secret", "payload": "{\"tool_name\": \"Write\", \"tool_input\": {\"content\": \"key = sk-ant-api03-abcdefghijklmnopqrst9\"}}", "expect": "block"}
+{"id": "unparseable", "payload": "not valid json but contains sk-ant-api03-abcdefghijklmnopqrst9 inline", "expect": "block"}
+{"id": "unrec_secret", "payload": "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"export K=sk-ant-api03-abcdefghijklmnopqrst9\"}}", "expect": "block"}
+{"id": "unrec_clean", "payload": "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"export K=ls -la\"}}", "expect": "warn"}

--- a/tests/test-secret-scanner.ps1
+++ b/tests/test-secret-scanner.ps1
@@ -1,0 +1,48 @@
+#Requires -Version 5.1
+# test-secret-scanner.ps1 - Windows-side parity test for secret-scanner.ps1.
+# Runs the shared fixtures (tests/fixtures/scanner-cases.jsonl) through the
+# PowerShell scanner and asserts exit code + WARNING behaviour matches the
+# expected outcome (the same fixtures the bash suite is checked against, so the
+# .ps1 and .sh stay behaviourally identical). Exits 1 on any mismatch.
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$scanner  = Join-Path $repoRoot 'hooks\secret-scanner.ps1'
+$fixtures = Join-Path $PSScriptRoot 'fixtures\scanner-cases.jsonl'
+
+if (-not (Test-Path $scanner))  { Write-Host "scanner not found: $scanner"; exit 1 }
+if (-not (Test-Path $fixtures)) { Write-Host "fixtures not found: $fixtures"; exit 1 }
+
+$pass = 0; $fail = 0
+foreach ($line in (Get-Content -Path $fixtures)) {
+  if (-not $line.Trim()) { continue }
+  $o = $line | ConvertFrom-Json
+  $inF  = [System.IO.Path]::GetTempFileName()
+  $outF = [System.IO.Path]::GetTempFileName()
+  $errF = [System.IO.Path]::GetTempFileName()
+  [System.IO.File]::WriteAllText($inF, $o.payload)
+  $p = Start-Process -FilePath 'powershell' `
+        -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File',"`"$scanner`"" `
+        -RedirectStandardInput $inF -RedirectStandardOutput $outF -RedirectStandardError $errF `
+        -NoNewWindow -PassThru -Wait
+  $ec = $p.ExitCode
+  $err = Get-Content -Path $errF -Raw
+  $warn = [bool]($err -match 'WARNING')
+  Remove-Item $inF,$outF,$errF -Force
+
+  switch ($o.expect) {
+    'block' { $ok = ($ec -eq 2) }
+    'allow' { $ok = (($ec -eq 0) -and (-not $warn)) }
+    'warn'  { $ok = (($ec -eq 0) -and $warn) }
+    default { $ok = $false }
+  }
+  if ($ok) {
+    $pass++
+    Write-Host ("  PASS {0} ({1})" -f $o.id, $o.expect)
+  } else {
+    $fail++
+    Write-Host ("  FAIL {0}: expect={1} exit={2} warn={3}" -f $o.id, $o.expect, $ec, $warn)
+  }
+}
+
+Write-Host ("`n=== PowerShell scanner parity: PASS={0} FAIL={1} ===" -f $pass, $fail)
+if ($fail -gt 0) { exit 1 } else { Write-Host 'All PowerShell scanner tests passed!'; exit 0 }


### PR DESCRIPTION
## Summary

Claude Code on Windows **without Git Bash** falls back to the PowerShell shell tool, where the `.sh` hooks cannot run — so the PreToolUse secret scanner would be **silently absent** on those machines (the platform-level version of the false-assurance the v3.4.4 fix, #54, addressed at the parse level). This ports both hooks to PowerShell. Closes the port scoped in #58.

**Verified on a real Windows box (PowerShell 5.1), not just CI:**
- `secret-scanner.ps1` is **38/38 behaviourally identical** to `secret-scanner.sh` across the shared fixtures — case-sensitive `-cmatch` + line-by-line scanning to mirror `grep -E`; the same 22 BLOCK + 3 two-stage DIGIT_REQUIRED + 3 WARN patterns; the same raw-scan fallback (never silent). Ground truth is the `.sh` output on the identical fixtures.
- `session-start.ps1` emits **byte-identical** SessionStart JSON (UTF-8 BOM so PS 5.1 renders the unicode arrows/em-dashes; verified `additionalContext` matches `.sh` exactly).

## What's included

- `hooks/secret-scanner.ps1`, `hooks/session-start.ps1` (+ `plugin/` mirror)
- `tests/fixtures/scanner-cases.jsonl` — shared SSOT fixtures (the bash suite is checked against the same set, so `.ps1`/`.sh` can't drift)
- `tests/test-secret-scanner.ps1` — Windows-side parity runner
- `.github/workflows/validate.yml`: a `powershell-hooks` job on `windows-latest` (parity test + `session-start.ps1` JSON validity)
- Platform Support table in `README.md`; notes in `CLAUDE.md` / `AGENTS.md`

## Deliberately deferred — auto-dispatch (#58)

`hooks/hooks.json` is **unchanged**. Claude Code exposes one hook `command` per event with no OS switch; selecting `.ps1` vs `.sh` per-OS without breaking macOS/Linux (or emitting per-edit errors there) needs a mechanism confirmable only on a real **authed** Windows + Claude Code install — which couldn't be reached here (npm's own `claude.ps1` shim is blocked by the default Restricted execution policy, and the box has no credentials). The `.ps1` hooks ship **ready and proven**; wiring them as the active hook is tracked in #58. A technical user can wire them manually via a personal `settings.json` hook running `powershell -NoProfile -ExecutionPolicy Bypass -File <path>`.

## Test plan

- [x] Real Windows PowerShell 5.1: `tests/test-secret-scanner.ps1` → 38 PASS / 0 FAIL
- [x] `session-start.ps1` output === `session-start.sh` output (semantic + `additionalContext` byte-identical) on Windows
- [x] `.ps1` runs under ExecutionPolicy **Restricted** via `-ExecutionPolicy Bypass` (verified on the box)
- [x] `bash tests/validate-plugin.sh --skip-install-check` → 150 PASS / 0 FAIL (incl. `diff -qr hooks` with the new `.ps1` mirrored)
- [x] `bash tests/test-secret-scanner.sh` → 44 PASS (bash side unchanged); `shellcheck --severity=warning` → 0
- [x] `windows-latest` CI job runs the PowerShell parity test (this PR)

## Scope

**Claude Code-only** — Codex does not run hooks. `hooks/hooks.json` untouched, so Codex install-time schema purity (#51) is unaffected. `tests/` and `.github/` are not part of the `plugin/` mirror; the `.ps1` hooks and docs are.