### PR TITLE
docs: rewrite README lean (genesis style) + extract docs/reference.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,504 +1,138 @@
-<p align="center">
-  <h1 align="center">claude-governance</h1>
-  <p align="center">
-    Governance framework for Claude Code and Codex — fitness functions, spec-driven development, ADRs, and OWASP DSGAI compliance.
-  </p>
-  <p align="center">
-    <a href="https://github.com/pitimon/claude-governance/actions/workflows/validate.yml"><img src="https://github.com/pitimon/claude-governance/actions/workflows/validate.yml/badge.svg" alt="Validate Plugin"></a>
-    <a href="https://github.com/pitimon/claude-governance/releases/latest"><img src="https://img.shields.io/github/v/release/pitimon/claude-governance?label=version" alt="Version"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/github/license/pitimon/claude-governance" alt="License"></a>
-    <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="Zero Dependencies">
-    <img src="https://img.shields.io/badge/OWASP_DSGAI-11_controls-orange" alt="DSGAI Controls">
-    <img src="https://img.shields.io/badge/languages-JS%2FTS%20%7C%20Python%20%7C%20Go%20%7C%20Rust-blue" alt="Language Support">
-  </p>
-</p>
+<div align="center">
 
-> Stop writing code. Start governing AI that writes code for you.
+# claude-governance
+
+**Keep AI-written code legible, safe, and accountable — from the first keystroke to the pull request.**
+
+A governance layer for Claude Code and Codex. Zero dependencies, zero build steps.
+
+</div>
 
 ---
 
-## Contents
+## The problem it targets
 
-**Start here:** [Why](#why-claude-governance) · [What you get on install](#what-happens-when-you-install-in-claude-code) · [Quick Start](#quick-start) · [Usage Examples](#real-world-usage-examples)
+AI writes code fast. The failures rarely come from bad code — they come from *ungoverned* code:
 
-**Reference:** [Features at a Glance](#features-at-a-glance) · [Core Concepts](#core-concepts) · [Architecture](#architecture) · [Platform Support](#platform-support) · [Token Budget](#token-budget)
+- A secret gets written straight into a file, then into git.
+- An agent runs an irreversible action — a production deploy, a data delete — that no human approved.
+- An architecture decision gets made, and six weeks later nobody remembers who chose it or why.
+- A team runs five different AI tools with no shared policy on what's allowed.
 
-**Contribute:** [Project Structure](#project-structure) · [Development](#development) · [Contributing](#contributing) · [Companion Plugins](#companion-plugins) · [References](#references)
-
----
-
-## Why claude-governance?
-
-AI-assisted development is fast — but ungoverned AI is a liability.
-
-| Without Governance                            | With claude-governance                                   |
-| --------------------------------------------- | -------------------------------------------------------- |
-| `sk-ant-api03-xxx` committed to git           | Blocked before it reaches the filesystem                 |
-| Junior dev deploys to production via AI       | Three Loops classifies it as In-the-Loop — human decides |
-| Prompt context leaks PII to observability     | Telemetry hygiene check flags `log(prompt)` patterns     |
-| Team uses 5 different AI tools with no policy | Shadow AI policy template — approved tools, data rules   |
-| "Who decided to use MongoDB?" — no one knows  | ADR system records every architecture decision           |
-
-**Zero dependencies.** Zero build steps. Markdown skills run in Claude Code and Codex; shell hooks run inside Claude Code.
+None of these is a model problem. They are *structure* problems — missing guardrails, missing approval gates, missing records. `claude-governance` adds that structure, and it does so without a runtime, a build step, or a single dependency: everything is Markdown skills, shell/PowerShell hooks, and declarative config.
 
 ---
 
-## What Happens When You Install In Claude Code
+## Two ways in
 
-```
-Session starts...
-
-  Governance Framework Active
-
-  Three Loops Decision Model:
-  - Out-of-Loop (AI autonomous): formatting, lint, simple fixes
-  - On-the-Loop (AI proposes): features, API changes
-  - In-the-Loop (Human decides): architecture, security, breaking changes
-
-  Consequence Override: Irreversible operations → always In-the-Loop
-```
-
-From this point, every Claude Code `Edit`/`Write` is scanned for secrets. In Codex, install exposes the governance skills and docs; run `governance-check` explicitly because Claude Code hooks do not run there.
-
----
-
-## Quick Start
+**You just want the guardrails.** Install in Claude Code. From the next session on, every `Edit`/`Write` is scanned for secrets before it touches disk, and each task is framed by the Three Loops model.
 
 ```bash
-# Claude Code install (one-time)
 claude plugin marketplace add pitimon/claude-governance
 claude plugin install claude-governance@claude-governance
-
-# (Optional) Install rules to ~/.claude/rules/
-bash ~/.claude/plugins/marketplaces/claude-governance/scripts/install-rules.sh
-
-# Codex install (skills + docs; Claude Code hooks do not run in Codex)
-codex plugin marketplace add pitimon/claude-governance
-codex plugin add claude-governance@pitimon-claude-governance
-
-# If you added the Codex marketplace before v3.4.0, refresh it first:
-codex plugin marketplace upgrade pitimon-claude-governance
 ```
 
----
-
-## Real-World Usage Examples
-
-### Catch a leaked API key before it enters git
-
-```
-You: Write the config file with the API key
-
-Claude writes: api_key = "sk-ant-api03-xxxxx"
-
-  Governance: Blocked — Anthropic API key detected.
-  Use environment variables instead:
-    JS/TS:  const value = process.env.YOUR_SECRET
-    Python: value = os.environ['YOUR_SECRET']
-    Go:     value := os.Getenv("YOUR_SECRET")
-```
-
-### Run pre-commit governance checks
-
-```
-You: /governance-check pre-commit
-
-  ## Governance Check: pre-commit
-
-  ### Passed
-  - [x] No hardcoded secrets found
-  - [x] Input validation present (Zod schema)
-  - [x] File sizes within limits
-  - [x] No debug prints in production
-
-  ### Failed
-  - [ ] FAIL: `src/ml/loader.py:12` — torch.load() without weights_only=True [DSGAI04]
-  - [ ] FAIL: `src/api/handler.ts` — 847 lines (max 800)
-
-  Passed: 8/10 | Failed: 2
-```
-
-### Classify a task with Three Loops + Consequence
-
-```
-You: Format the deployment config and push to production
-
-Claude: This task is Out-of-Loop (formatting) BUT involves irreversible
-        consequence (production deploy). Per ADR-002 Consequence Override:
-        Irreversible → always In-the-Loop.
-
-        I'll format the file, but you should review and deploy manually.
-```
-
-### Initialize governance in a new project
-
-```
-You: /governance-setup
-
-  Step 1: Creating DOMAIN.md...
-  Step 2: Setting up docs/adr/
-  Step 3: Data Classification (Optional)
-  Step 3.5: Shadow AI Policy (Optional)
-  Step 4: Install Rules
-
-  Governance initialized:
-  - DOMAIN.md — edit to define your entities
-  - docs/adr/ADR-001 — governance adoption record
-  - DATA-CLASSIFICATION.md — data sensitivity levels
-  - shadow-ai-policy.md — approved AI tools
-```
-
----
-
-## Features at a Glance
-
-### Always-On (Hooks)
-
-| Hook                   | Trigger              | What It Does                                             |
-| ---------------------- | -------------------- | -------------------------------------------------------- |
-| **Governance context** | Session start        | Injects Three Loops + Consequence Override (~360 tokens) |
-| **Secret scanner**     | Every `Edit`/`Write` | 25 BLOCK patterns (secrets) + 3 WARN patterns (PII)      |
-
-### On-Demand (Skills & Agent)
-
-| Command               | When to Use                   | Example                                       |
-| --------------------- | ----------------------------- | --------------------------------------------- |
-| `/governance-check`   | Before commit/push            | `/governance-check pre-commit`                |
-| `/create-adr`         | After architecture decision   | `/create-adr "Adopt PostgreSQL over MongoDB"` |
-| `/spec-driven-dev`    | Before feature implementation | `/spec-driven-dev` → writes spec.md           |
-| `/governance-setup`   | New project initialization    | Creates DOMAIN.md, ADRs, rules                |
-| `/eu-ai-act-check`    | Before high-risk AI release   | EU AI Act Arts 9-15 readiness checklist       |
-| `/iso-42001-check`    | Before AIMS audit / attest    | ISO/IEC 42001:2023 AIMS 9-clause checklist    |
-| `governance-reviewer` | Before PR (auto-triggered)    | Deep multi-file review with severity grading  |
-
-### 31 Governance Checks
-
-| Category         | Count | Key Checks                                                                                                        |
-| ---------------- | ----- | ----------------------------------------------------------------------------------------------------------------- |
-| **Pre-Commit**   | 14    | Secrets, input validation, file size, debug prints, AI model artifacts, unsafe deserialization, telemetry hygiene |
-| **Pre-PR**       | 5     | Conventional commits, DOMAIN.md sync, test coverage >= 80%                                                        |
-| **Architecture** | 12    | Service boundaries, auth coverage, plugin/MCP security, session isolation, consequence safeguards                 |
-
-### OWASP DSGAI Compliance — 11 Controls
-
-Mapped to [OWASP GenAI Data Security](https://genai.owasp.org) v1.0 (March 2026):
-
-| Control | Risk                      | What We Do                                                       |
-| ------- | ------------------------- | ---------------------------------------------------------------- |
-| DSGAI01 | Sensitive Data Leakage    | PII WARN patterns (email, SSN, credit card)                      |
-| DSGAI02 | Agent Credential Exposure | BLOCK patterns for OAuth, Bearer, refresh tokens                 |
-| DSGAI03 | Shadow AI                 | Policy template with approved alternatives                       |
-| DSGAI04 | Data/Model Poisoning      | Model file detection, unsafe deserialization, dependency pinning |
-| DSGAI06 | Plugin/Tool Data Exchange | MCP security checklist, least-privilege checks                   |
-| DSGAI07 | Data Classification       | 4-level classification template with AI/LLM data flows           |
-| DSGAI08 | Compliance Violations     | This compliance mapping + `[DSGAI##]` tags in all outputs        |
-| DSGAI11 | Cross-Context Bleed       | Session isolation, multi-tenant separation checks                |
-| DSGAI14 | Telemetry Leakage         | Flags `log(prompt)` patterns in production code                  |
-| DSGAI15 | Over-Broad Context        | Context minimization checks, token budget enforcement            |
-| DSGAI19 | Human-in-the-Loop Gaps    | Consequence-based auth — irreversible ops always In-the-Loop     |
-
-See [docs/compliance/DSGAI-MAPPING.md](docs/compliance/DSGAI-MAPPING.md) for the full control-by-control mapping.
-
-### Language Support
-
-Governance checks detect the project's language and apply stack-specific rules:
-
-| Check        | JS/TS                 | Python                               | Go               | Rust             |
-| ------------ | --------------------- | ------------------------------------ | ---------------- | ---------------- |
-| Debug prints | `console.log`         | `print()`                            | `fmt.Println`    | `println!`       |
-| Validation   | Zod, joi, yup         | pydantic, marshmallow                | go-validator     | serde, validator |
-| Dangerous    | `eval()`, `innerHTML` | `eval()`, `exec()`, `pickle.loads()` | `unsafe.Pointer` | `unsafe` blocks  |
-| Detection    | `package.json`        | `pyproject.toml`                     | `go.mod`         | `Cargo.toml`     |
-
-### Ready-to-Use Templates
-
-| Template                         | Purpose                                              | Reference |
-| -------------------------------- | ---------------------------------------------------- | --------- |
-| `DATA-CLASSIFICATION.md.example` | 4-level data sensitivity with AI/LLM data flows      | DSGAI07   |
-| `mcp-security-checklist.md`      | Plugin/MCP vetting before installation               | DSGAI06   |
-| `shadow-ai-policy.md`            | Approved AI tools, data rules, exceptions            | DSGAI03   |
-| `ai-supply-chain-checklist.md`   | Model vetting, dependency pinning, safe alternatives | DSGAI04   |
-| `DOMAIN.md.example`              | Entity definitions, invariants, API contracts        | —         |
-| `adr-template.md`                | Architecture Decision Record with governance loop    | —         |
-
-### Rules for `~/.claude/rules/`
-
-| Rule              | Focus                                                                       |
-| ----------------- | --------------------------------------------------------------------------- |
-| `governance.md`   | Fitness functions: pre-implementation, pre-commit, pre-PR, architecture     |
-| `security.md`     | Secret management, agent/plugin security, PII, telemetry, session isolation |
-| `coding-style.md` | Immutability, file size limits, error handling                              |
-| `git-workflow.md` | Conventional commits, PR workflow, TDD                                      |
-| `testing.md`      | 80% coverage minimum, unit/integration/E2E                                  |
-
----
-
-## Core Concepts
-
-### Three Loops + Consequence-Based Authorization
-
-Every task is classified on two dimensions:
-
-```
-                      Task Type
-                      Out-of-Loop    On-the-Loop    In-the-Loop
-Consequence
-  Reversible          autonomous      propose         human-driven
-  Contained           autonomous      propose         human-driven
-  Broad               propose         propose         human-driven
-  Irreversible        HUMAN-DRIVEN    HUMAN-DRIVEN    human-driven
-```
-
-**Override rule:** Irreversible operations (production deploy, data deletion, credential rotation) are **always In-the-Loop** — even if the task itself is trivial. See [ADR-002](docs/adr/ADR-002-consequence-based-authorization.md).
-
-### Fitness Functions
-
-Automated governance checks — "unit tests for architecture":
-
-| Stage                  | What Gets Checked                                                                                                                     |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| **Pre-Implementation** | Spec exists, domain invariants identified, autonomy classified, irreversible ops flagged                                              |
-| **Pre-Commit**         | 14 checks: secrets, PII, validation, file size, functions, immutability, debug prints, AI artifacts, deserialization, deps, telemetry |
-| **Pre-PR**             | 5 checks: conventional commits, DOMAIN.md, breaking changes, test coverage, TODO context                                              |
-| **Architecture**       | 12 checks: service boundaries, auth, rate limiting, plugin/MCP, context minimization, session isolation, consequence safeguards       |
-
-### Spec-Driven Development
-
-```
-Understand ──> Specify ──> Plan ──> Implement ──> Verify
-     │              │          │          │            │
-  Explore       Write      Plan Mode  Code to     Check criteria
-  codebase      spec.md    from spec  spec        Run tests
-  Clarify       Acceptance            On-the-Loop Validate domain
-  requirements  criteria              iterations  invariants
-```
-
----
-
-## Architecture
-
-```
-                       ┌────────────────────────────┐
-                       │  Claude Code Session       │
-                       └─────────────┬──────────────┘
-                                     │
-              ┌──────────────────────┼──────────────────────┐
-              ▼                      ▼                      ▼
-       ┌─────────────┐        ┌─────────────┐       ┌──────────────┐
-       │  Always-On  │        │  On-Demand  │       │   Config     │
-       └──────┬──────┘        └──────┬──────┘       └──────┬───────┘
-              │                      │                      │
-   ┌──────────┴──────────┐  ┌────────┴─────────┐  ┌────────┴─────────┐
-   │ SessionStart Hook   │  │ /governance-check│  │ ~/.claude/rules/ │
-   │  Three Loops +      │  │   31 checks /    │  │   5 rule files   │
-   │  Consequence        │  │   3 categories   │  │                  │
-   │  ~360 tokens        │  │                  │  │ Templates        │
-   │                     │  │ /create-adr      │  │   7 examples     │
-   │ PreToolUse Hook     │  │ /spec-driven-dev │  │                  │
-   │  Secret Scanner     │  │ /governance-setup│  │ Always loaded if │
-   │  25 BLOCK + 3 WARN  │  │                  │  │ installed.       │
-   │  blocks file writes │  │ governance-      │  │                  │
-   └─────────────────────┘  │ reviewer agent   │  └──────────────────┘
-                            │   deep + severity│
-                            │ /eu-ai-act-check │
-                            │ /iso-42001-check │
-                            └──────────────────┘
-
-   ┌──────────────────────────────────────────────────────────────┐
-   │  Compliance Anchors                                          │
-   │  • DSGAI-MAPPING.md → 11 OWASP DSGAI controls                │
-   │  • docs/adr/        → ADR set (see docs/adr/)                │
-   └──────────────────────────────────────────────────────────────┘
-```
-
-→ **[docs/architecture/etclovg-coverage.md](docs/architecture/etclovg-coverage.md)** — ETCLOVG 7-layer taxonomy coverage map (Agent Harness Engineering). Anchor for future scope-expansion decisions: `G` strong, `V/L/C` partial, `O` none, `E/T` out-of-scope by charter / plugin boundary.
-
-### Agent Harness Coverage (ETCLOVG)
-
-<!-- Mirror of docs/architecture/etclovg-coverage.md § Per-layer coverage (single source of truth). Update both in the same PR to avoid drift. See issue #46. -->
-
-`Agent = Model + Harness`. The **ETCLOVG taxonomy** (Agent Harness Engineering, 2026) defines 7 layers that wrap a model to make it a reliable autonomous agent: **E**xecution, **T**ooling, **C**ontext+Memory, **L**ifecycle, **O**bservability, **V**erification, **G**overnance. This plugin's per-layer coverage:
-
-| Layer                             |        Status         | What ships today                                                                                                                                                                                                                                     | Gap / Why not                                                                     |
-| --------------------------------- | :-------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **E** — Execution Environment     |     `OOS-charter`     | —                                                                                                                                                                                                                                                    | "Skills are read-only guidance" — charter-amendment ADR required to re-evaluate   |
-| **T** — Tooling (MCP / A2A)       | `OOS-plugin-boundary` | —                                                                                                                                                                                                                                                    | Routed to sibling plugin `pitimon/devsecops-ai-team` (plugin boundary)            |
-| **C** — Context & Memory          |       `Partial`       | `hooks/session-start.sh` (~360 tokens/session — Progressive Disclosure); skills lazy-load on `/command`                                                                                                                                              | No Compaction or Context Resets                                                   |
-| **L** — Lifecycle & Orchestration |       `Partial`       | Three Loops + Consequence Override (ADR-002) — autonomy classification with irreversible-op gating                                                                                                                                                   | No multi-agent orchestration or Planner-Generator-Evaluator structural separation |
-| **O** — Observability             |        `None`         | —                                                                                                                                                                                                                                                    | No trace / telemetry / SLA metrics — awaiting first-person friction signal        |
-| **V** — Verification              |       `Partial`       | 31 fitness functions (pre-commit / pre-PR / architecture), `governance-reviewer` agent, `validate-plugin.sh` (100+ structural checks)                                                                                                                | "Verify Before You Fix" sandbox gate not yet codified                             |
-| **G** — Governance & Security     |     **`Strong`**      | (1) Three Loops + Consequence Override (ADR-002) · (2) `secret-scanner.sh` 25 BLOCK + 3 WARN · (3) `governance-reviewer` agent · (4) 31 governance checks · (5) Compliance mappings: EU AI Act / ISO 42001 / NIST AI RMF / OWASP DSGAI (11 controls) | — primary focus                                                                   |
-
-**Coverage summary**:
-
-| Status                | Count | Layers  |
-| --------------------- | ----: | ------- |
-| `Strong`              |     1 | G       |
-| `Partial`             |     3 | C, L, V |
-| `None`                |     1 | O       |
-| `OOS-charter`         |     1 | E       |
-| `OOS-plugin-boundary` |     1 | T       |
-
-> **Friction-first**: `Partial` is not an invitation to expand. Per ADR-014 in `8-habit-ai-dev`, pattern attractiveness alone is not a shipping criterion — a first-person friction case (issue, lesson, post-mortem) must be cited before any `Partial` → `Strong` move.
->
-> **Adopter shorthand**: use `claude-governance` for **G strong** + **V/L/C partial**. For **E (sandbox)** or **T (MCP)**, pair with [`pitimon/devsecops-ai-team`](https://github.com/pitimon/devsecops-ai-team).
-
----
-
-## Platform Support
-
-Skills, ADRs, and compliance docs are plain Markdown and work identically everywhere. The **hooks** (SessionStart context + PreToolUse secret scanner) are the only platform-sensitive surface:
-
-| Environment | Hook behaviour |
-| --- | --- |
-| macOS / Linux | `.sh` hooks run via bash (default) |
-| Windows **with** Git for Windows | `.sh` hooks run via Git Bash (Claude Code's default shell there) |
-| Windows **without** Git Bash | Claude Code falls back to the PowerShell shell tool; `.sh` hooks cannot run. PowerShell ports — `hooks/secret-scanner.ps1`, `hooks/session-start.ps1` — are provided and verified byte-for-byte equivalent to the bash hooks (parity gated on a `windows-latest` CI job). |
-| **Codex** (any OS) | Does not run hooks at all — skills are used as explicit checklists. |
-
-> **Native-Windows auto-dispatch is not yet wired into the default `hooks/hooks.json`.** Claude Code exposes a single hook `command` per event with no OS switch, and selecting the right script per-OS without breaking macOS/Linux users (or spamming them with per-edit errors) needs a mechanism that can only be confirmed on a real Windows + Claude Code install. That validation is tracked in **[#58](https://github.com/pitimon/claude-governance/issues/58)**. The `.ps1` hooks ship now (proven on Windows PowerShell 5.1) so the port is ready the moment dispatch is confirmed; a technical user can also wire them manually via a personal `settings.json` PreToolUse/SessionStart hook that runs `powershell -NoProfile -ExecutionPolicy Bypass -File <path>` (Windows PowerShell requires `-ExecutionPolicy Bypass` under the default Restricted policy).
-
-**Requirement for the PowerShell path:** Windows 10 1809+ with Windows PowerShell 5.1 (included by default).
-
----
-
-## Token Budget
-
-| Component            | Tokens   | When                        |
-| -------------------- | -------- | --------------------------- |
-| SessionStart hook    | ~360     | Every session               |
-| Secret scanner       | 0        | Shell script, no token cost |
-| Rules (if installed) | ~500-800 | Every session               |
-| Skills / agent       | 0        | Only when invoked           |
-
-**Total always-on cost:** ~360 tokens (without rules) / ~1,160 tokens (with rules)
-
----
-
-## Project Structure
-
-```
-claude-governance/
-├── .claude-plugin/
-│   ├── plugin.json              # Plugin metadata, skills path, keywords
-│   └── marketplace.json         # Marketplace listing schema
-├── .codex-plugin/
-│   └── plugin.json              # Codex plugin metadata, shared skills path
-├── .agents/plugins/
-│   └── marketplace.json         # Codex marketplace listing
-├── plugin/                      # Codex marketplace child package mirror
-├── hooks/
-│   ├── hooks.json               # Hook registrations (SessionStart, PreToolUse)
-│   ├── session-start.sh         # Three Loops + Consequence Override injection
-│   └── secret-scanner.sh        # 25 BLOCK + 3 WARN patterns, dual-loop
-├── skills/
-│   ├── governance-check/SKILL.md  # 31 checks across 3 categories
-│   ├── create-adr/SKILL.md       # ADR generator with governance loop
-│   ├── spec-driven-dev/SKILL.md   # Spec-first development workflow
-│   ├── governance-setup/SKILL.md  # 6-step project initialization
-│   ├── eu-ai-act-check/SKILL.md   # EU AI Act readiness checklist
-│   └── iso-42001-check/SKILL.md   # ISO/IEC 42001 AIMS readiness checklist
-├── agents/
-│   └── governance-reviewer.md   # Deep compliance review with severity grading
-├── examples/
-│   ├── rules/                   # 5 rules for ~/.claude/rules/
-│   ├── DATA-CLASSIFICATION.md.example  # Data sensitivity template [DSGAI07]
-│   ├── mcp-security-checklist.md       # MCP/plugin security [DSGAI06]
-│   ├── shadow-ai-policy.md            # Shadow AI policy [DSGAI03]
-│   ├── ai-supply-chain-checklist.md   # AI artifact vetting [DSGAI04]
-│   ├── DOMAIN.md.example              # Domain model template
-│   ├── adr-template.md                # ADR template
-│   └── project-claude-md.example
-├── docs/
-│   ├── INTEGRATION.md            # Companion-plugin integration stub (SSOT in 8-habit-ai-dev)
-│   ├── notebooklm-workflow.md    # NotebookLM ↔ Claude Code grounded-corpus workflow
-│   ├── adr/                      # 8 Architecture Decision Records
-│   │   ├── ADR-001-adopt-governance-framework.md
-│   │   ├── ADR-002-consequence-based-authorization.md
-│   │   ├── ADR-003-eu-ai-act-compliance-toolkit.md
-│   │   ├── ADR-004-iso-42001-framework-selection.md
-│   │   ├── ADR-005-nist-ai-rmf-cross-reference-doc.md
-│   │   ├── ADR-006-hook-design-principle-write-vs-edit.md
-│   │   ├── ADR-007-codex-native-packaging.md
-│   │   └── ADR-008-governance-reviewer-model-inherit.md
-│   ├── architecture/
-│   │   └── etclovg-coverage.md   # ETCLOVG 7-layer taxonomy map (Agent Harness Engineering)
-│   ├── compliance/               # Framework mappings (4 files)
-│   │   ├── DSGAI-MAPPING.md       # 11 OWASP DSGAI controls mapped
-│   │   ├── EU-AI-ACT-MAPPING.md   # EU AI Act Arts 9-15 mapping
-│   │   ├── ISO-42001-MAPPING.md   # ISO/IEC 42001:2023 AIMS controls
-│   │   └── NIST-AI-RMF-MAPPING.md # NIST AI RMF 1.0 cross-reference
-│   └── research/                 # Compliance research briefs (EU AI Act, NIST AI RMF)
-├── scripts/
-│   ├── install-rules.sh         # Rules installer with backup
-│   └── bump-version.sh          # Version sync across Claude + Codex manifests
-├── tests/
-│   ├── validate-plugin.sh       # Structural integrity (100+ checks in CI)
-│   ├── test-secret-scanner.sh   # 40 pattern-by-pattern tests
-│   └── test-release-qa.sh       # 166 QA checks (8-Habit verified; runs in CI)
-├── .github/workflows/
-│   └── validate.yml             # CI: structural + scanner tests
-├── CHANGELOG.md
-├── README.md
-└── LICENSE
-```
-
----
-
-## Development
+**You're setting up a project or a team.** Run `/governance-setup` to lay down a domain model, an ADR log, a data-classification template, a shadow-AI policy, and (optionally) the shared rule set.
 
 ```bash
-# Structural validation (100+ checks — CI signal)
-bash tests/validate-plugin.sh --skip-install-check
-
-# Scanner pattern tests (40 tests)
-bash tests/test-secret-scanner.sh
-
-# Full QA suite (166 checks, 8-Habit verified; local-only)
-bash tests/test-release-qa.sh
-
-# Bump version
-bash scripts/bump-version.sh X.Y.Z
+# Optional: install the rule set into ~/.claude/rules/
+bash ~/.claude/plugins/marketplaces/claude-governance/scripts/install-rules.sh
 ```
+
+**On Codex** the skills and docs install the same way; hooks do not run there, so you invoke the checks explicitly.
+
+```bash
+codex plugin marketplace add pitimon/claude-governance
+codex plugin add claude-governance@pitimon-claude-governance
+```
+
+---
+
+## The whole thing on one page
+
+```
+                      Claude Code / Codex session
+                                 │
+        ┌────────────────────────┼────────────────────────┐
+        ▼                        ▼                         ▼
+   Always-On hooks          On-demand skills           Config
+   (Claude Code only)       (both runtimes)            (if installed)
+        │                        │                         │
+  SessionStart:            /governance-check          ~/.claude/rules/
+   Three Loops +           /create-adr                 5 rule files
+   Consequence             /spec-driven-dev
+   (~360 tokens)           /governance-setup           examples/
+                           /eu-ai-act-check             templates
+  PreToolUse:              /iso-42001-check
+   Secret scanner          governance-reviewer agent
+   25 BLOCK + 3 WARN
+   blocks file writes
+```
+
+---
+
+## How it works — Three Loops + Consequence
+
+Every task is classified on two axes: **who drives** (Three Loops) and **how bad it is if it goes wrong** (consequence).
+
+- **Out-of-Loop** — AI acts autonomously: formatting, lint, simple fixes.
+- **On-the-Loop** — AI proposes, human approves: features, API changes.
+- **In-the-Loop** — human drives, AI assists: architecture, security, breaking changes.
+
+**The override that matters:** any *irreversible* operation — production deploy, data deletion, credential rotation — is **always In-the-Loop**, even when the task itself is trivial. "Format the config and push to prod" is a formatting task with an irreversible tail, so the human decides. See [ADR-002](docs/adr/ADR-002-consequence-based-authorization.md).
+
+---
+
+## Design principles
+
+1. **Zero dependencies.** Markdown, shell, and config. Nothing to install, build, or keep patched.
+2. **Deny-by-default on secrets.** The scanner blocks a write before it reaches disk — it doesn't warn after the fact.
+3. **Consequence over capability.** Autonomy is granted by blast radius, not by how simple the task looks. Irreversible always stops for a human.
+4. **Friction-first.** The plugin expands only when a real case — an issue, a lesson, a post-mortem — demands it. Attractiveness is not a shipping criterion.
+5. **A standard, not a lock-in.** The same plain-Markdown governance runs in Claude Code and Codex. Pair it with sibling plugins or run it entirely on its own.
+6. **Governance is the whole job.** This plugin does one layer — `G` for Governance — deeply, and points elsewhere for the rest (see coverage below).
+
+---
+
+## What it ships
+
+- **2 hooks** — governance-context injection + secret scanner (25 BLOCK / 3 WARN patterns).
+- **6 skills** — `/governance-check`, `/create-adr`, `/spec-driven-dev`, `/governance-setup`, `/eu-ai-act-check`, `/iso-42001-check`.
+- **1 agent** — `governance-reviewer`, a deep multi-file review with severity grading.
+- **31 governance checks** across pre-commit, pre-PR, and architecture stages, language-aware for JS/TS, Python, Go, and Rust.
+- **4 compliance mappings** — OWASP DSGAI (11 controls), EU AI Act (Arts 9-15), ISO/IEC 42001:2023, NIST AI RMF 1.0.
+- **Ready-to-use templates** — data classification, shadow-AI policy, MCP-security checklist, AI supply-chain checklist, DOMAIN and ADR templates.
+
+**Go deeper:**
+
+- **[docs/reference.md](docs/reference.md)** — full feature reference: every hook, skill, check, template, rule, platform note, and the token budget.
+- **Compliance** — [DSGAI](docs/compliance/DSGAI-MAPPING.md) · [EU AI Act](docs/compliance/EU-AI-ACT-MAPPING.md) · [ISO 42001](docs/compliance/ISO-42001-MAPPING.md) · [NIST AI RMF](docs/compliance/NIST-AI-RMF-MAPPING.md).
+- **[Agent-harness coverage (ETCLOVG)](docs/architecture/etclovg-coverage.md)** — where this plugin is strong (`G`), partial (`C/L/V`), and deliberately out of scope (`E/T`). Adopter shorthand: use `claude-governance` for governance; pair with [`pitimon/devsecops-ai-team`](https://github.com/pitimon/devsecops-ai-team) for sandboxing (`E`) or MCP tooling (`T`).
+
+---
+
+## Standards vs. examples
+
+What the plugin *enforces* — the hooks and the 31 checks — is fixed and versioned. What it *offers* — the templates and rules — is a starting point you copy and edit for your project. Don't confuse the two: the guardrails are the product; the templates are scaffolding.
+
+---
+
+## Companion plugins
+
+`claude-governance` works **fully standalone**. For teams that also use `8-habit-ai-dev` (workflow method) and/or `devsecops-ai-team` (operational tooling), the canonical integration guide lives in `8-habit-ai-dev` to avoid drift — see the local stub at **[docs/INTEGRATION.md](docs/INTEGRATION.md)**. Tested against `8-habit-ai-dev` 2.21.42 and `devsecops-ai-team` 10.15.0.
 
 ---
 
 ## Contributing
 
-Areas where help is welcome:
-
-- Fitness function examples for other tech stacks (Ruby, PHP, Java, C#)
-- Language-specific secret and PII patterns
-- Translations (i18n for session-start context)
-- Real-world case studies and governance templates
-- OWASP DSGAI Tier 3 controls (DSGAI05, DSGAI12, DSGAI13)
-
-See [CHANGELOG.md](CHANGELOG.md) for version history.
-
----
-
-## Companion Plugins
-
-`claude-governance` works **fully standalone**. For projects that combine it with `8-habit-ai-dev` (workflow method) and/or `devsecops-ai-team` (operational tooling), the canonical integration guide lives in `8-habit-ai-dev` to prevent SSOT drift across version bumps:
-
-→ **[docs/INTEGRATION.md](docs/INTEGRATION.md)** (local stub) — links to the canonical guide and notes governance-specific points (Three Loops + ADR-002, EU AI Act canonical role per ADR-003).
-
-Tested against `8-habit-ai-dev` 2.21.42 and `devsecops-ai-team` 10.15.0.
-
----
-
-## References
-
-- **Fitness Functions** — _Building Evolutionary Architectures_ (Ford, Parsons, Kua — O'Reilly)
-- **ADRs** — _Lightweight Architecture Decision Records_ (ThoughtWorks Technology Radar)
-- **Spec-Driven Dev** — Derived from Design-by-Contract (Meyer, 1986)
-- **Three Loops** — Human-AI interaction model for autonomous systems
-- **Consequence-Based Auth** — See [ADR-002](docs/adr/ADR-002-consequence-based-authorization.md) — extends Three Loops with blast radius
-- **OWASP DSGAI** — _GenAI Data Security Risks and Mitigations_ v1.0 (March 2026) — [genai.owasp.org](https://genai.owasp.org)
-- **Compliance Mapping** — See [docs/compliance/DSGAI-MAPPING.md](docs/compliance/DSGAI-MAPPING.md) for 11 controls
+Help is welcome on: fitness-function examples for other stacks (Ruby, PHP, Java, C#), language-specific secret/PII patterns, session-context translations, real-world governance templates, and OWASP DSGAI Tier-3 controls (DSGAI05, DSGAI12, DSGAI13). See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/reference.md](docs/reference.md#development) for the local test commands.
 
 ---
 
 ## License
 
-[MIT](LICENSE) — Copyright (c) 2026 pitimon
+[MIT](LICENSE) — Copyright (c) 2026 pitimon.
+
+> กติกาที่ดีไม่ได้ทำให้คนเก่งขึ้น — แต่ทำให้ระบบไม่พังลง แม้ในวันที่คนพลาด.
+>
+> *Good rules don't make people smarter — they keep the system from breaking on the day someone slips.*

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,201 @@
+# Reference
+
+Full feature reference for `claude-governance`. The [README](../README.md) is the
+narrative overview; this is the lookup table.
+
+- [Hooks (always-on)](#hooks-always-on)
+- [Skills & agent (on-demand)](#skills--agent-on-demand)
+- [Governance checks (31)](#governance-checks-31)
+- [Fitness function stages](#fitness-function-stages)
+- [Language support](#language-support)
+- [Templates](#templates)
+- [Rules for `~/.claude/rules/`](#rules-for-clauderules)
+- [Platform support](#platform-support)
+- [Token budget](#token-budget)
+- [Project structure](#project-structure)
+- [Development](#development)
+
+Compliance mappings and the agent-harness coverage map live in their own docs:
+[DSGAI](compliance/DSGAI-MAPPING.md) · [EU AI Act](compliance/EU-AI-ACT-MAPPING.md) ·
+[ISO 42001](compliance/ISO-42001-MAPPING.md) · [NIST AI RMF](compliance/NIST-AI-RMF-MAPPING.md) ·
+[ETCLOVG coverage](architecture/etclovg-coverage.md).
+
+---
+
+## Hooks (always-on)
+
+Run automatically inside Claude Code. Codex does not run hooks.
+
+| Hook                   | Trigger              | What it does                                             |
+| ---------------------- | -------------------- | -------------------------------------------------------- |
+| **Governance context** | Session start        | Injects Three Loops + Consequence Override (~360 tokens) |
+| **Secret scanner**     | Every `Edit`/`Write` | 25 BLOCK patterns (secrets) + 3 WARN patterns (PII)      |
+
+## Skills & agent (on-demand)
+
+| Command               | When to use                   | Example                                       |
+| --------------------- | ----------------------------- | --------------------------------------------- |
+| `/governance-check`   | Before commit/push            | `/governance-check pre-commit`                |
+| `/create-adr`         | After an architecture decision| `/create-adr "Adopt PostgreSQL over MongoDB"` |
+| `/spec-driven-dev`    | Before feature implementation | `/spec-driven-dev` → writes `spec.md`         |
+| `/governance-setup`   | New-project initialization    | Creates `DOMAIN.md`, ADRs, rules              |
+| `/eu-ai-act-check`    | Before a high-risk AI release | EU AI Act Arts 9-15 readiness checklist       |
+| `/iso-42001-check`    | Before an AIMS audit / attest | ISO/IEC 42001:2023 AIMS 9-clause checklist    |
+| `governance-reviewer` | Before a PR (auto-triggered)  | Deep multi-file review with severity grading  |
+
+## Governance checks (31)
+
+| Category         | Count | Key checks                                                                                                        |
+| ---------------- | ----- | ----------------------------------------------------------------------------------------------------------------- |
+| **Pre-Commit**   | 14    | Secrets, input validation, file size, debug prints, AI model artifacts, unsafe deserialization, telemetry hygiene |
+| **Pre-PR**       | 5     | Conventional commits, DOMAIN.md sync, test coverage >= 80%                                                        |
+| **Architecture** | 12    | Service boundaries, auth coverage, plugin/MCP security, session isolation, consequence safeguards                 |
+
+## Fitness function stages
+
+Automated governance checks — "unit tests for architecture":
+
+| Stage                  | What gets checked                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pre-Implementation** | Spec exists, domain invariants identified, autonomy classified, irreversible ops flagged                                              |
+| **Pre-Commit**         | 14 checks: secrets, PII, validation, file size, functions, immutability, debug prints, AI artifacts, deserialization, deps, telemetry |
+| **Pre-PR**             | 5 checks: conventional commits, DOMAIN.md, breaking changes, test coverage, TODO context                                             |
+| **Architecture**       | 12 checks: service boundaries, auth, rate limiting, plugin/MCP, context minimization, session isolation, consequence safeguards       |
+
+## Language support
+
+Governance checks detect the project's language and apply stack-specific rules:
+
+| Check        | JS/TS                 | Python                               | Go               | Rust             |
+| ------------ | --------------------- | ------------------------------------ | ---------------- | ---------------- |
+| Debug prints | `console.log`         | `print()`                            | `fmt.Println`    | `println!`       |
+| Validation   | Zod, joi, yup         | pydantic, marshmallow                | go-validator     | serde, validator |
+| Dangerous    | `eval()`, `innerHTML` | `eval()`, `exec()`, `pickle.loads()` | `unsafe.Pointer` | `unsafe` blocks  |
+| Detection    | `package.json`        | `pyproject.toml`                     | `go.mod`         | `Cargo.toml`     |
+
+## Templates
+
+Ready-to-use templates shipped in `examples/`:
+
+| Template                         | Purpose                                              | Reference |
+| -------------------------------- | ---------------------------------------------------- | --------- |
+| `DATA-CLASSIFICATION.md.example` | 4-level data sensitivity with AI/LLM data flows      | DSGAI07   |
+| `mcp-security-checklist.md`      | Plugin/MCP vetting before installation               | DSGAI06   |
+| `shadow-ai-policy.md`            | Approved AI tools, data rules, exceptions            | DSGAI03   |
+| `ai-supply-chain-checklist.md`   | Model vetting, dependency pinning, safe alternatives | DSGAI04   |
+| `DOMAIN.md.example`              | Entity definitions, invariants, API contracts        | —         |
+| `adr-template.md`                | Architecture Decision Record with governance loop    | —         |
+| `project-claude-md.example`      | Example project `CLAUDE.md` with governance sections | —         |
+
+## Rules for `~/.claude/rules/`
+
+Optional — install with `bash ~/.claude/plugins/marketplaces/claude-governance/scripts/install-rules.sh`.
+
+| Rule              | Focus                                                                       |
+| ----------------- | --------------------------------------------------------------------------- |
+| `governance.md`   | Fitness functions: pre-implementation, pre-commit, pre-PR, architecture     |
+| `security.md`     | Secret management, agent/plugin security, PII, telemetry, session isolation |
+| `coding-style.md` | Immutability, file size limits, error handling                              |
+| `git-workflow.md` | Conventional commits, PR workflow, TDD                                      |
+| `testing.md`      | 80% coverage minimum, unit/integration/E2E                                  |
+
+## Platform support
+
+Skills, ADRs, and compliance docs are plain Markdown and work identically everywhere.
+The **hooks** (SessionStart context + PreToolUse secret scanner) are the only
+platform-sensitive surface:
+
+| Environment | Hook behaviour |
+| --- | --- |
+| macOS / Linux | `.sh` hooks run via bash (default) |
+| Windows **with** Git for Windows | `.sh` hooks run via Git Bash (Claude Code's default shell there) |
+| Windows **without** Git Bash | Claude Code falls back to the PowerShell shell tool; `.sh` hooks cannot run. PowerShell ports — `hooks/secret-scanner.ps1`, `hooks/session-start.ps1` — are provided and verified byte-for-byte equivalent to the bash hooks (parity gated on a `windows-latest` CI job). |
+| **Codex** (any OS) | Does not run hooks at all — skills are used as explicit checklists. |
+
+> **Native-Windows auto-dispatch is not yet wired into the default `hooks/hooks.json`.**
+> Claude Code exposes a single hook `command` per event with no OS switch, and selecting the
+> right script per-OS without breaking macOS/Linux users needs a mechanism that can only be
+> confirmed on a real Windows + Claude Code install (tracked in
+> [#58](https://github.com/pitimon/claude-governance/issues/58)). The `.ps1` hooks ship now
+> (proven on Windows PowerShell 5.1); a technical user can wire them manually via a personal
+> `settings.json` PreToolUse/SessionStart hook that runs
+> `powershell -NoProfile -ExecutionPolicy Bypass -File <path>` (the default Restricted policy
+> requires `-ExecutionPolicy Bypass`).
+
+**Requirement for the PowerShell path:** Windows 10 1809+ with Windows PowerShell 5.1 (included by default).
+
+## Token budget
+
+| Component            | Tokens   | When                        |
+| -------------------- | -------- | --------------------------- |
+| SessionStart hook    | ~360     | Every session               |
+| Secret scanner       | 0        | Shell script, no token cost |
+| Rules (if installed) | ~500-800 | Every session               |
+| Skills / agent       | 0        | Only when invoked           |
+
+**Total always-on cost:** ~360 tokens (without rules) / ~1,160 tokens (with rules).
+
+## Project structure
+
+```
+claude-governance/
+├── .claude-plugin/
+│   ├── plugin.json              # Plugin metadata, skills path, keywords
+│   └── marketplace.json         # Marketplace listing schema
+├── .codex-plugin/
+│   └── plugin.json              # Codex plugin metadata, shared skills path
+├── .agents/plugins/
+│   └── marketplace.json         # Codex marketplace listing
+├── plugin/                      # Codex marketplace child package mirror
+├── hooks/
+│   ├── hooks.json               # Hook registrations (SessionStart, PreToolUse)
+│   ├── session-start.sh         # Three Loops + Consequence Override injection
+│   ├── secret-scanner.sh        # 25 BLOCK + 3 WARN patterns, dual-loop
+│   ├── session-start.ps1        # PowerShell port (native Windows)
+│   └── secret-scanner.ps1       # PowerShell port (native Windows)
+├── skills/
+│   ├── governance-check/SKILL.md   # 31 checks across 3 categories
+│   ├── create-adr/SKILL.md         # ADR generator with governance loop
+│   ├── spec-driven-dev/SKILL.md    # Spec-first development workflow
+│   ├── governance-setup/SKILL.md   # 6-step project initialization
+│   ├── eu-ai-act-check/SKILL.md     # EU AI Act readiness checklist
+│   └── iso-42001-check/SKILL.md     # ISO/IEC 42001 AIMS readiness checklist
+├── agents/
+│   └── governance-reviewer.md   # Deep compliance review with severity grading
+├── examples/
+│   ├── rules/                   # 5 rules for ~/.claude/rules/
+│   └── *.example, *.md          # Templates (see Templates above)
+├── docs/
+│   ├── INTEGRATION.md           # Companion-plugin integration stub
+│   ├── notebooklm-workflow.md   # NotebookLM ↔ Claude Code grounded-corpus workflow
+│   ├── reference.md             # This file
+│   ├── adr/                     # 8 Architecture Decision Records
+│   ├── architecture/            # ETCLOVG 7-layer coverage map
+│   ├── compliance/              # DSGAI / EU AI Act / ISO 42001 / NIST AI RMF mappings
+│   └── research/                # Compliance research briefs
+├── scripts/
+│   ├── install-rules.sh         # Rules installer with backup
+│   └── bump-version.sh          # Version sync across Claude + Codex manifests
+├── tests/
+│   ├── validate-plugin.sh       # Structural integrity (100+ checks in CI)
+│   ├── test-secret-scanner.sh   # Pattern-by-pattern scanner tests
+│   └── test-release-qa.sh       # Release QA checks (runs in CI)
+└── .github/workflows/
+    └── validate.yml             # CI: structural + scanner + shellcheck + PowerShell parity
+```
+
+## Development
+
+```bash
+# Structural validation (100+ checks — CI signal)
+bash tests/validate-plugin.sh --skip-install-check
+
+# Scanner pattern tests
+bash tests/test-secret-scanner.sh
+
+# Release QA suite (8-Habit verified)
+bash tests/test-release-qa.sh
+
+# Bump version across all manifests
+bash scripts/bump-version.sh X.Y.Z
+```

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,504 +1,138 @@
-<p align="center">
-  <h1 align="center">claude-governance</h1>
-  <p align="center">
-    Governance framework for Claude Code and Codex — fitness functions, spec-driven development, ADRs, and OWASP DSGAI compliance.
-  </p>
-  <p align="center">
-    <a href="https://github.com/pitimon/claude-governance/actions/workflows/validate.yml"><img src="https://github.com/pitimon/claude-governance/actions/workflows/validate.yml/badge.svg" alt="Validate Plugin"></a>
-    <a href="https://github.com/pitimon/claude-governance/releases/latest"><img src="https://img.shields.io/github/v/release/pitimon/claude-governance?label=version" alt="Version"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/github/license/pitimon/claude-governance" alt="License"></a>
-    <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="Zero Dependencies">
-    <img src="https://img.shields.io/badge/OWASP_DSGAI-11_controls-orange" alt="DSGAI Controls">
-    <img src="https://img.shields.io/badge/languages-JS%2FTS%20%7C%20Python%20%7C%20Go%20%7C%20Rust-blue" alt="Language Support">
-  </p>
-</p>
+<div align="center">
 
-> Stop writing code. Start governing AI that writes code for you.
+# claude-governance
+
+**Keep AI-written code legible, safe, and accountable — from the first keystroke to the pull request.**
+
+A governance layer for Claude Code and Codex. Zero dependencies, zero build steps.
+
+</div>
 
 ---
 
-## Contents
+## The problem it targets
 
-**Start here:** [Why](#why-claude-governance) · [What you get on install](#what-happens-when-you-install-in-claude-code) · [Quick Start](#quick-start) · [Usage Examples](#real-world-usage-examples)
+AI writes code fast. The failures rarely come from bad code — they come from *ungoverned* code:
 
-**Reference:** [Features at a Glance](#features-at-a-glance) · [Core Concepts](#core-concepts) · [Architecture](#architecture) · [Platform Support](#platform-support) · [Token Budget](#token-budget)
+- A secret gets written straight into a file, then into git.
+- An agent runs an irreversible action — a production deploy, a data delete — that no human approved.
+- An architecture decision gets made, and six weeks later nobody remembers who chose it or why.
+- A team runs five different AI tools with no shared policy on what's allowed.
 
-**Contribute:** [Project Structure](#project-structure) · [Development](#development) · [Contributing](#contributing) · [Companion Plugins](#companion-plugins) · [References](#references)
-
----
-
-## Why claude-governance?
-
-AI-assisted development is fast — but ungoverned AI is a liability.
-
-| Without Governance                            | With claude-governance                                   |
-| --------------------------------------------- | -------------------------------------------------------- |
-| `sk-ant-api03-xxx` committed to git           | Blocked before it reaches the filesystem                 |
-| Junior dev deploys to production via AI       | Three Loops classifies it as In-the-Loop — human decides |
-| Prompt context leaks PII to observability     | Telemetry hygiene check flags `log(prompt)` patterns     |
-| Team uses 5 different AI tools with no policy | Shadow AI policy template — approved tools, data rules   |
-| "Who decided to use MongoDB?" — no one knows  | ADR system records every architecture decision           |
-
-**Zero dependencies.** Zero build steps. Markdown skills run in Claude Code and Codex; shell hooks run inside Claude Code.
+None of these is a model problem. They are *structure* problems — missing guardrails, missing approval gates, missing records. `claude-governance` adds that structure, and it does so without a runtime, a build step, or a single dependency: everything is Markdown skills, shell/PowerShell hooks, and declarative config.
 
 ---
 
-## What Happens When You Install In Claude Code
+## Two ways in
 
-```
-Session starts...
-
-  Governance Framework Active
-
-  Three Loops Decision Model:
-  - Out-of-Loop (AI autonomous): formatting, lint, simple fixes
-  - On-the-Loop (AI proposes): features, API changes
-  - In-the-Loop (Human decides): architecture, security, breaking changes
-
-  Consequence Override: Irreversible operations → always In-the-Loop
-```
-
-From this point, every Claude Code `Edit`/`Write` is scanned for secrets. In Codex, install exposes the governance skills and docs; run `governance-check` explicitly because Claude Code hooks do not run there.
-
----
-
-## Quick Start
+**You just want the guardrails.** Install in Claude Code. From the next session on, every `Edit`/`Write` is scanned for secrets before it touches disk, and each task is framed by the Three Loops model.
 
 ```bash
-# Claude Code install (one-time)
 claude plugin marketplace add pitimon/claude-governance
 claude plugin install claude-governance@claude-governance
-
-# (Optional) Install rules to ~/.claude/rules/
-bash ~/.claude/plugins/marketplaces/claude-governance/scripts/install-rules.sh
-
-# Codex install (skills + docs; Claude Code hooks do not run in Codex)
-codex plugin marketplace add pitimon/claude-governance
-codex plugin add claude-governance@pitimon-claude-governance
-
-# If you added the Codex marketplace before v3.4.0, refresh it first:
-codex plugin marketplace upgrade pitimon-claude-governance
 ```
 
----
-
-## Real-World Usage Examples
-
-### Catch a leaked API key before it enters git
-
-```
-You: Write the config file with the API key
-
-Claude writes: api_key = "sk-ant-api03-xxxxx"
-
-  Governance: Blocked — Anthropic API key detected.
-  Use environment variables instead:
-    JS/TS:  const value = process.env.YOUR_SECRET
-    Python: value = os.environ['YOUR_SECRET']
-    Go:     value := os.Getenv("YOUR_SECRET")
-```
-
-### Run pre-commit governance checks
-
-```
-You: /governance-check pre-commit
-
-  ## Governance Check: pre-commit
-
-  ### Passed
-  - [x] No hardcoded secrets found
-  - [x] Input validation present (Zod schema)
-  - [x] File sizes within limits
-  - [x] No debug prints in production
-
-  ### Failed
-  - [ ] FAIL: `src/ml/loader.py:12` — torch.load() without weights_only=True [DSGAI04]
-  - [ ] FAIL: `src/api/handler.ts` — 847 lines (max 800)
-
-  Passed: 8/10 | Failed: 2
-```
-
-### Classify a task with Three Loops + Consequence
-
-```
-You: Format the deployment config and push to production
-
-Claude: This task is Out-of-Loop (formatting) BUT involves irreversible
-        consequence (production deploy). Per ADR-002 Consequence Override:
-        Irreversible → always In-the-Loop.
-
-        I'll format the file, but you should review and deploy manually.
-```
-
-### Initialize governance in a new project
-
-```
-You: /governance-setup
-
-  Step 1: Creating DOMAIN.md...
-  Step 2: Setting up docs/adr/
-  Step 3: Data Classification (Optional)
-  Step 3.5: Shadow AI Policy (Optional)
-  Step 4: Install Rules
-
-  Governance initialized:
-  - DOMAIN.md — edit to define your entities
-  - docs/adr/ADR-001 — governance adoption record
-  - DATA-CLASSIFICATION.md — data sensitivity levels
-  - shadow-ai-policy.md — approved AI tools
-```
-
----
-
-## Features at a Glance
-
-### Always-On (Hooks)
-
-| Hook                   | Trigger              | What It Does                                             |
-| ---------------------- | -------------------- | -------------------------------------------------------- |
-| **Governance context** | Session start        | Injects Three Loops + Consequence Override (~360 tokens) |
-| **Secret scanner**     | Every `Edit`/`Write` | 25 BLOCK patterns (secrets) + 3 WARN patterns (PII)      |
-
-### On-Demand (Skills & Agent)
-
-| Command               | When to Use                   | Example                                       |
-| --------------------- | ----------------------------- | --------------------------------------------- |
-| `/governance-check`   | Before commit/push            | `/governance-check pre-commit`                |
-| `/create-adr`         | After architecture decision   | `/create-adr "Adopt PostgreSQL over MongoDB"` |
-| `/spec-driven-dev`    | Before feature implementation | `/spec-driven-dev` → writes spec.md           |
-| `/governance-setup`   | New project initialization    | Creates DOMAIN.md, ADRs, rules                |
-| `/eu-ai-act-check`    | Before high-risk AI release   | EU AI Act Arts 9-15 readiness checklist       |
-| `/iso-42001-check`    | Before AIMS audit / attest    | ISO/IEC 42001:2023 AIMS 9-clause checklist    |
-| `governance-reviewer` | Before PR (auto-triggered)    | Deep multi-file review with severity grading  |
-
-### 31 Governance Checks
-
-| Category         | Count | Key Checks                                                                                                        |
-| ---------------- | ----- | ----------------------------------------------------------------------------------------------------------------- |
-| **Pre-Commit**   | 14    | Secrets, input validation, file size, debug prints, AI model artifacts, unsafe deserialization, telemetry hygiene |
-| **Pre-PR**       | 5     | Conventional commits, DOMAIN.md sync, test coverage >= 80%                                                        |
-| **Architecture** | 12    | Service boundaries, auth coverage, plugin/MCP security, session isolation, consequence safeguards                 |
-
-### OWASP DSGAI Compliance — 11 Controls
-
-Mapped to [OWASP GenAI Data Security](https://genai.owasp.org) v1.0 (March 2026):
-
-| Control | Risk                      | What We Do                                                       |
-| ------- | ------------------------- | ---------------------------------------------------------------- |
-| DSGAI01 | Sensitive Data Leakage    | PII WARN patterns (email, SSN, credit card)                      |
-| DSGAI02 | Agent Credential Exposure | BLOCK patterns for OAuth, Bearer, refresh tokens                 |
-| DSGAI03 | Shadow AI                 | Policy template with approved alternatives                       |
-| DSGAI04 | Data/Model Poisoning      | Model file detection, unsafe deserialization, dependency pinning |
-| DSGAI06 | Plugin/Tool Data Exchange | MCP security checklist, least-privilege checks                   |
-| DSGAI07 | Data Classification       | 4-level classification template with AI/LLM data flows           |
-| DSGAI08 | Compliance Violations     | This compliance mapping + `[DSGAI##]` tags in all outputs        |
-| DSGAI11 | Cross-Context Bleed       | Session isolation, multi-tenant separation checks                |
-| DSGAI14 | Telemetry Leakage         | Flags `log(prompt)` patterns in production code                  |
-| DSGAI15 | Over-Broad Context        | Context minimization checks, token budget enforcement            |
-| DSGAI19 | Human-in-the-Loop Gaps    | Consequence-based auth — irreversible ops always In-the-Loop     |
-
-See [docs/compliance/DSGAI-MAPPING.md](docs/compliance/DSGAI-MAPPING.md) for the full control-by-control mapping.
-
-### Language Support
-
-Governance checks detect the project's language and apply stack-specific rules:
-
-| Check        | JS/TS                 | Python                               | Go               | Rust             |
-| ------------ | --------------------- | ------------------------------------ | ---------------- | ---------------- |
-| Debug prints | `console.log`         | `print()`                            | `fmt.Println`    | `println!`       |
-| Validation   | Zod, joi, yup         | pydantic, marshmallow                | go-validator     | serde, validator |
-| Dangerous    | `eval()`, `innerHTML` | `eval()`, `exec()`, `pickle.loads()` | `unsafe.Pointer` | `unsafe` blocks  |
-| Detection    | `package.json`        | `pyproject.toml`                     | `go.mod`         | `Cargo.toml`     |
-
-### Ready-to-Use Templates
-
-| Template                         | Purpose                                              | Reference |
-| -------------------------------- | ---------------------------------------------------- | --------- |
-| `DATA-CLASSIFICATION.md.example` | 4-level data sensitivity with AI/LLM data flows      | DSGAI07   |
-| `mcp-security-checklist.md`      | Plugin/MCP vetting before installation               | DSGAI06   |
-| `shadow-ai-policy.md`            | Approved AI tools, data rules, exceptions            | DSGAI03   |
-| `ai-supply-chain-checklist.md`   | Model vetting, dependency pinning, safe alternatives | DSGAI04   |
-| `DOMAIN.md.example`              | Entity definitions, invariants, API contracts        | —         |
-| `adr-template.md`                | Architecture Decision Record with governance loop    | —         |
-
-### Rules for `~/.claude/rules/`
-
-| Rule              | Focus                                                                       |
-| ----------------- | --------------------------------------------------------------------------- |
-| `governance.md`   | Fitness functions: pre-implementation, pre-commit, pre-PR, architecture     |
-| `security.md`     | Secret management, agent/plugin security, PII, telemetry, session isolation |
-| `coding-style.md` | Immutability, file size limits, error handling                              |
-| `git-workflow.md` | Conventional commits, PR workflow, TDD                                      |
-| `testing.md`      | 80% coverage minimum, unit/integration/E2E                                  |
-
----
-
-## Core Concepts
-
-### Three Loops + Consequence-Based Authorization
-
-Every task is classified on two dimensions:
-
-```
-                      Task Type
-                      Out-of-Loop    On-the-Loop    In-the-Loop
-Consequence
-  Reversible          autonomous      propose         human-driven
-  Contained           autonomous      propose         human-driven
-  Broad               propose         propose         human-driven
-  Irreversible        HUMAN-DRIVEN    HUMAN-DRIVEN    human-driven
-```
-
-**Override rule:** Irreversible operations (production deploy, data deletion, credential rotation) are **always In-the-Loop** — even if the task itself is trivial. See [ADR-002](docs/adr/ADR-002-consequence-based-authorization.md).
-
-### Fitness Functions
-
-Automated governance checks — "unit tests for architecture":
-
-| Stage                  | What Gets Checked                                                                                                                     |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| **Pre-Implementation** | Spec exists, domain invariants identified, autonomy classified, irreversible ops flagged                                              |
-| **Pre-Commit**         | 14 checks: secrets, PII, validation, file size, functions, immutability, debug prints, AI artifacts, deserialization, deps, telemetry |
-| **Pre-PR**             | 5 checks: conventional commits, DOMAIN.md, breaking changes, test coverage, TODO context                                              |
-| **Architecture**       | 12 checks: service boundaries, auth, rate limiting, plugin/MCP, context minimization, session isolation, consequence safeguards       |
-
-### Spec-Driven Development
-
-```
-Understand ──> Specify ──> Plan ──> Implement ──> Verify
-     │              │          │          │            │
-  Explore       Write      Plan Mode  Code to     Check criteria
-  codebase      spec.md    from spec  spec        Run tests
-  Clarify       Acceptance            On-the-Loop Validate domain
-  requirements  criteria              iterations  invariants
-```
-
----
-
-## Architecture
-
-```
-                       ┌────────────────────────────┐
-                       │  Claude Code Session       │
-                       └─────────────┬──────────────┘
-                                     │
-              ┌──────────────────────┼──────────────────────┐
-              ▼                      ▼                      ▼
-       ┌─────────────┐        ┌─────────────┐       ┌──────────────┐
-       │  Always-On  │        │  On-Demand  │       │   Config     │
-       └──────┬──────┘        └──────┬──────┘       └──────┬───────┘
-              │                      │                      │
-   ┌──────────┴──────────┐  ┌────────┴─────────┐  ┌────────┴─────────┐
-   │ SessionStart Hook   │  │ /governance-check│  │ ~/.claude/rules/ │
-   │  Three Loops +      │  │   31 checks /    │  │   5 rule files   │
-   │  Consequence        │  │   3 categories   │  │                  │
-   │  ~360 tokens        │  │                  │  │ Templates        │
-   │                     │  │ /create-adr      │  │   7 examples     │
-   │ PreToolUse Hook     │  │ /spec-driven-dev │  │                  │
-   │  Secret Scanner     │  │ /governance-setup│  │ Always loaded if │
-   │  25 BLOCK + 3 WARN  │  │                  │  │ installed.       │
-   │  blocks file writes │  │ governance-      │  │                  │
-   └─────────────────────┘  │ reviewer agent   │  └──────────────────┘
-                            │   deep + severity│
-                            │ /eu-ai-act-check │
-                            │ /iso-42001-check │
-                            └──────────────────┘
-
-   ┌──────────────────────────────────────────────────────────────┐
-   │  Compliance Anchors                                          │
-   │  • DSGAI-MAPPING.md → 11 OWASP DSGAI controls                │
-   │  • docs/adr/        → ADR set (see docs/adr/)                │
-   └──────────────────────────────────────────────────────────────┘
-```
-
-→ **[docs/architecture/etclovg-coverage.md](docs/architecture/etclovg-coverage.md)** — ETCLOVG 7-layer taxonomy coverage map (Agent Harness Engineering). Anchor for future scope-expansion decisions: `G` strong, `V/L/C` partial, `O` none, `E/T` out-of-scope by charter / plugin boundary.
-
-### Agent Harness Coverage (ETCLOVG)
-
-<!-- Mirror of docs/architecture/etclovg-coverage.md § Per-layer coverage (single source of truth). Update both in the same PR to avoid drift. See issue #46. -->
-
-`Agent = Model + Harness`. The **ETCLOVG taxonomy** (Agent Harness Engineering, 2026) defines 7 layers that wrap a model to make it a reliable autonomous agent: **E**xecution, **T**ooling, **C**ontext+Memory, **L**ifecycle, **O**bservability, **V**erification, **G**overnance. This plugin's per-layer coverage:
-
-| Layer                             |        Status         | What ships today                                                                                                                                                                                                                                     | Gap / Why not                                                                     |
-| --------------------------------- | :-------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **E** — Execution Environment     |     `OOS-charter`     | —                                                                                                                                                                                                                                                    | "Skills are read-only guidance" — charter-amendment ADR required to re-evaluate   |
-| **T** — Tooling (MCP / A2A)       | `OOS-plugin-boundary` | —                                                                                                                                                                                                                                                    | Routed to sibling plugin `pitimon/devsecops-ai-team` (plugin boundary)            |
-| **C** — Context & Memory          |       `Partial`       | `hooks/session-start.sh` (~360 tokens/session — Progressive Disclosure); skills lazy-load on `/command`                                                                                                                                              | No Compaction or Context Resets                                                   |
-| **L** — Lifecycle & Orchestration |       `Partial`       | Three Loops + Consequence Override (ADR-002) — autonomy classification with irreversible-op gating                                                                                                                                                   | No multi-agent orchestration or Planner-Generator-Evaluator structural separation |
-| **O** — Observability             |        `None`         | —                                                                                                                                                                                                                                                    | No trace / telemetry / SLA metrics — awaiting first-person friction signal        |
-| **V** — Verification              |       `Partial`       | 31 fitness functions (pre-commit / pre-PR / architecture), `governance-reviewer` agent, `validate-plugin.sh` (100+ structural checks)                                                                                                                | "Verify Before You Fix" sandbox gate not yet codified                             |
-| **G** — Governance & Security     |     **`Strong`**      | (1) Three Loops + Consequence Override (ADR-002) · (2) `secret-scanner.sh` 25 BLOCK + 3 WARN · (3) `governance-reviewer` agent · (4) 31 governance checks · (5) Compliance mappings: EU AI Act / ISO 42001 / NIST AI RMF / OWASP DSGAI (11 controls) | — primary focus                                                                   |
-
-**Coverage summary**:
-
-| Status                | Count | Layers  |
-| --------------------- | ----: | ------- |
-| `Strong`              |     1 | G       |
-| `Partial`             |     3 | C, L, V |
-| `None`                |     1 | O       |
-| `OOS-charter`         |     1 | E       |
-| `OOS-plugin-boundary` |     1 | T       |
-
-> **Friction-first**: `Partial` is not an invitation to expand. Per ADR-014 in `8-habit-ai-dev`, pattern attractiveness alone is not a shipping criterion — a first-person friction case (issue, lesson, post-mortem) must be cited before any `Partial` → `Strong` move.
->
-> **Adopter shorthand**: use `claude-governance` for **G strong** + **V/L/C partial**. For **E (sandbox)** or **T (MCP)**, pair with [`pitimon/devsecops-ai-team`](https://github.com/pitimon/devsecops-ai-team).
-
----
-
-## Platform Support
-
-Skills, ADRs, and compliance docs are plain Markdown and work identically everywhere. The **hooks** (SessionStart context + PreToolUse secret scanner) are the only platform-sensitive surface:
-
-| Environment | Hook behaviour |
-| --- | --- |
-| macOS / Linux | `.sh` hooks run via bash (default) |
-| Windows **with** Git for Windows | `.sh` hooks run via Git Bash (Claude Code's default shell there) |
-| Windows **without** Git Bash | Claude Code falls back to the PowerShell shell tool; `.sh` hooks cannot run. PowerShell ports — `hooks/secret-scanner.ps1`, `hooks/session-start.ps1` — are provided and verified byte-for-byte equivalent to the bash hooks (parity gated on a `windows-latest` CI job). |
-| **Codex** (any OS) | Does not run hooks at all — skills are used as explicit checklists. |
-
-> **Native-Windows auto-dispatch is not yet wired into the default `hooks/hooks.json`.** Claude Code exposes a single hook `command` per event with no OS switch, and selecting the right script per-OS without breaking macOS/Linux users (or spamming them with per-edit errors) needs a mechanism that can only be confirmed on a real Windows + Claude Code install. That validation is tracked in **[#58](https://github.com/pitimon/claude-governance/issues/58)**. The `.ps1` hooks ship now (proven on Windows PowerShell 5.1) so the port is ready the moment dispatch is confirmed; a technical user can also wire them manually via a personal `settings.json` PreToolUse/SessionStart hook that runs `powershell -NoProfile -ExecutionPolicy Bypass -File <path>` (Windows PowerShell requires `-ExecutionPolicy Bypass` under the default Restricted policy).
-
-**Requirement for the PowerShell path:** Windows 10 1809+ with Windows PowerShell 5.1 (included by default).
-
----
-
-## Token Budget
-
-| Component            | Tokens   | When                        |
-| -------------------- | -------- | --------------------------- |
-| SessionStart hook    | ~360     | Every session               |
-| Secret scanner       | 0        | Shell script, no token cost |
-| Rules (if installed) | ~500-800 | Every session               |
-| Skills / agent       | 0        | Only when invoked           |
-
-**Total always-on cost:** ~360 tokens (without rules) / ~1,160 tokens (with rules)
-
----
-
-## Project Structure
-
-```
-claude-governance/
-├── .claude-plugin/
-│   ├── plugin.json              # Plugin metadata, skills path, keywords
-│   └── marketplace.json         # Marketplace listing schema
-├── .codex-plugin/
-│   └── plugin.json              # Codex plugin metadata, shared skills path
-├── .agents/plugins/
-│   └── marketplace.json         # Codex marketplace listing
-├── plugin/                      # Codex marketplace child package mirror
-├── hooks/
-│   ├── hooks.json               # Hook registrations (SessionStart, PreToolUse)
-│   ├── session-start.sh         # Three Loops + Consequence Override injection
-│   └── secret-scanner.sh        # 25 BLOCK + 3 WARN patterns, dual-loop
-├── skills/
-│   ├── governance-check/SKILL.md  # 31 checks across 3 categories
-│   ├── create-adr/SKILL.md       # ADR generator with governance loop
-│   ├── spec-driven-dev/SKILL.md   # Spec-first development workflow
-│   ├── governance-setup/SKILL.md  # 6-step project initialization
-│   ├── eu-ai-act-check/SKILL.md   # EU AI Act readiness checklist
-│   └── iso-42001-check/SKILL.md   # ISO/IEC 42001 AIMS readiness checklist
-├── agents/
-│   └── governance-reviewer.md   # Deep compliance review with severity grading
-├── examples/
-│   ├── rules/                   # 5 rules for ~/.claude/rules/
-│   ├── DATA-CLASSIFICATION.md.example  # Data sensitivity template [DSGAI07]
-│   ├── mcp-security-checklist.md       # MCP/plugin security [DSGAI06]
-│   ├── shadow-ai-policy.md            # Shadow AI policy [DSGAI03]
-│   ├── ai-supply-chain-checklist.md   # AI artifact vetting [DSGAI04]
-│   ├── DOMAIN.md.example              # Domain model template
-│   ├── adr-template.md                # ADR template
-│   └── project-claude-md.example
-├── docs/
-│   ├── INTEGRATION.md            # Companion-plugin integration stub (SSOT in 8-habit-ai-dev)
-│   ├── notebooklm-workflow.md    # NotebookLM ↔ Claude Code grounded-corpus workflow
-│   ├── adr/                      # 8 Architecture Decision Records
-│   │   ├── ADR-001-adopt-governance-framework.md
-│   │   ├── ADR-002-consequence-based-authorization.md
-│   │   ├── ADR-003-eu-ai-act-compliance-toolkit.md
-│   │   ├── ADR-004-iso-42001-framework-selection.md
-│   │   ├── ADR-005-nist-ai-rmf-cross-reference-doc.md
-│   │   ├── ADR-006-hook-design-principle-write-vs-edit.md
-│   │   ├── ADR-007-codex-native-packaging.md
-│   │   └── ADR-008-governance-reviewer-model-inherit.md
-│   ├── architecture/
-│   │   └── etclovg-coverage.md   # ETCLOVG 7-layer taxonomy map (Agent Harness Engineering)
-│   ├── compliance/               # Framework mappings (4 files)
-│   │   ├── DSGAI-MAPPING.md       # 11 OWASP DSGAI controls mapped
-│   │   ├── EU-AI-ACT-MAPPING.md   # EU AI Act Arts 9-15 mapping
-│   │   ├── ISO-42001-MAPPING.md   # ISO/IEC 42001:2023 AIMS controls
-│   │   └── NIST-AI-RMF-MAPPING.md # NIST AI RMF 1.0 cross-reference
-│   └── research/                 # Compliance research briefs (EU AI Act, NIST AI RMF)
-├── scripts/
-│   ├── install-rules.sh         # Rules installer with backup
-│   └── bump-version.sh          # Version sync across Claude + Codex manifests
-├── tests/
-│   ├── validate-plugin.sh       # Structural integrity (100+ checks in CI)
-│   ├── test-secret-scanner.sh   # 40 pattern-by-pattern tests
-│   └── test-release-qa.sh       # 166 QA checks (8-Habit verified; runs in CI)
-├── .github/workflows/
-│   └── validate.yml             # CI: structural + scanner tests
-├── CHANGELOG.md
-├── README.md
-└── LICENSE
-```
-
----
-
-## Development
+**You're setting up a project or a team.** Run `/governance-setup` to lay down a domain model, an ADR log, a data-classification template, a shadow-AI policy, and (optionally) the shared rule set.
 
 ```bash
-# Structural validation (100+ checks — CI signal)
-bash tests/validate-plugin.sh --skip-install-check
-
-# Scanner pattern tests (40 tests)
-bash tests/test-secret-scanner.sh
-
-# Full QA suite (166 checks, 8-Habit verified; local-only)
-bash tests/test-release-qa.sh
-
-# Bump version
-bash scripts/bump-version.sh X.Y.Z
+# Optional: install the rule set into ~/.claude/rules/
+bash ~/.claude/plugins/marketplaces/claude-governance/scripts/install-rules.sh
 ```
+
+**On Codex** the skills and docs install the same way; hooks do not run there, so you invoke the checks explicitly.
+
+```bash
+codex plugin marketplace add pitimon/claude-governance
+codex plugin add claude-governance@pitimon-claude-governance
+```
+
+---
+
+## The whole thing on one page
+
+```
+                      Claude Code / Codex session
+                                 │
+        ┌────────────────────────┼────────────────────────┐
+        ▼                        ▼                         ▼
+   Always-On hooks          On-demand skills           Config
+   (Claude Code only)       (both runtimes)            (if installed)
+        │                        │                         │
+  SessionStart:            /governance-check          ~/.claude/rules/
+   Three Loops +           /create-adr                 5 rule files
+   Consequence             /spec-driven-dev
+   (~360 tokens)           /governance-setup           examples/
+                           /eu-ai-act-check             templates
+  PreToolUse:              /iso-42001-check
+   Secret scanner          governance-reviewer agent
+   25 BLOCK + 3 WARN
+   blocks file writes
+```
+
+---
+
+## How it works — Three Loops + Consequence
+
+Every task is classified on two axes: **who drives** (Three Loops) and **how bad it is if it goes wrong** (consequence).
+
+- **Out-of-Loop** — AI acts autonomously: formatting, lint, simple fixes.
+- **On-the-Loop** — AI proposes, human approves: features, API changes.
+- **In-the-Loop** — human drives, AI assists: architecture, security, breaking changes.
+
+**The override that matters:** any *irreversible* operation — production deploy, data deletion, credential rotation — is **always In-the-Loop**, even when the task itself is trivial. "Format the config and push to prod" is a formatting task with an irreversible tail, so the human decides. See [ADR-002](docs/adr/ADR-002-consequence-based-authorization.md).
+
+---
+
+## Design principles
+
+1. **Zero dependencies.** Markdown, shell, and config. Nothing to install, build, or keep patched.
+2. **Deny-by-default on secrets.** The scanner blocks a write before it reaches disk — it doesn't warn after the fact.
+3. **Consequence over capability.** Autonomy is granted by blast radius, not by how simple the task looks. Irreversible always stops for a human.
+4. **Friction-first.** The plugin expands only when a real case — an issue, a lesson, a post-mortem — demands it. Attractiveness is not a shipping criterion.
+5. **A standard, not a lock-in.** The same plain-Markdown governance runs in Claude Code and Codex. Pair it with sibling plugins or run it entirely on its own.
+6. **Governance is the whole job.** This plugin does one layer — `G` for Governance — deeply, and points elsewhere for the rest (see coverage below).
+
+---
+
+## What it ships
+
+- **2 hooks** — governance-context injection + secret scanner (25 BLOCK / 3 WARN patterns).
+- **6 skills** — `/governance-check`, `/create-adr`, `/spec-driven-dev`, `/governance-setup`, `/eu-ai-act-check`, `/iso-42001-check`.
+- **1 agent** — `governance-reviewer`, a deep multi-file review with severity grading.
+- **31 governance checks** across pre-commit, pre-PR, and architecture stages, language-aware for JS/TS, Python, Go, and Rust.
+- **4 compliance mappings** — OWASP DSGAI (11 controls), EU AI Act (Arts 9-15), ISO/IEC 42001:2023, NIST AI RMF 1.0.
+- **Ready-to-use templates** — data classification, shadow-AI policy, MCP-security checklist, AI supply-chain checklist, DOMAIN and ADR templates.
+
+**Go deeper:**
+
+- **[docs/reference.md](docs/reference.md)** — full feature reference: every hook, skill, check, template, rule, platform note, and the token budget.
+- **Compliance** — [DSGAI](docs/compliance/DSGAI-MAPPING.md) · [EU AI Act](docs/compliance/EU-AI-ACT-MAPPING.md) · [ISO 42001](docs/compliance/ISO-42001-MAPPING.md) · [NIST AI RMF](docs/compliance/NIST-AI-RMF-MAPPING.md).
+- **[Agent-harness coverage (ETCLOVG)](docs/architecture/etclovg-coverage.md)** — where this plugin is strong (`G`), partial (`C/L/V`), and deliberately out of scope (`E/T`). Adopter shorthand: use `claude-governance` for governance; pair with [`pitimon/devsecops-ai-team`](https://github.com/pitimon/devsecops-ai-team) for sandboxing (`E`) or MCP tooling (`T`).
+
+---
+
+## Standards vs. examples
+
+What the plugin *enforces* — the hooks and the 31 checks — is fixed and versioned. What it *offers* — the templates and rules — is a starting point you copy and edit for your project. Don't confuse the two: the guardrails are the product; the templates are scaffolding.
+
+---
+
+## Companion plugins
+
+`claude-governance` works **fully standalone**. For teams that also use `8-habit-ai-dev` (workflow method) and/or `devsecops-ai-team` (operational tooling), the canonical integration guide lives in `8-habit-ai-dev` to avoid drift — see the local stub at **[docs/INTEGRATION.md](docs/INTEGRATION.md)**. Tested against `8-habit-ai-dev` 2.21.42 and `devsecops-ai-team` 10.15.0.
 
 ---
 
 ## Contributing
 
-Areas where help is welcome:
-
-- Fitness function examples for other tech stacks (Ruby, PHP, Java, C#)
-- Language-specific secret and PII patterns
-- Translations (i18n for session-start context)
-- Real-world case studies and governance templates
-- OWASP DSGAI Tier 3 controls (DSGAI05, DSGAI12, DSGAI13)
-
-See [CHANGELOG.md](CHANGELOG.md) for version history.
-
----
-
-## Companion Plugins
-
-`claude-governance` works **fully standalone**. For projects that combine it with `8-habit-ai-dev` (workflow method) and/or `devsecops-ai-team` (operational tooling), the canonical integration guide lives in `8-habit-ai-dev` to prevent SSOT drift across version bumps:
-
-→ **[docs/INTEGRATION.md](docs/INTEGRATION.md)** (local stub) — links to the canonical guide and notes governance-specific points (Three Loops + ADR-002, EU AI Act canonical role per ADR-003).
-
-Tested against `8-habit-ai-dev` 2.21.42 and `devsecops-ai-team` 10.15.0.
-
----
-
-## References
-
-- **Fitness Functions** — _Building Evolutionary Architectures_ (Ford, Parsons, Kua — O'Reilly)
-- **ADRs** — _Lightweight Architecture Decision Records_ (ThoughtWorks Technology Radar)
-- **Spec-Driven Dev** — Derived from Design-by-Contract (Meyer, 1986)
-- **Three Loops** — Human-AI interaction model for autonomous systems
-- **Consequence-Based Auth** — See [ADR-002](docs/adr/ADR-002-consequence-based-authorization.md) — extends Three Loops with blast radius
-- **OWASP DSGAI** — _GenAI Data Security Risks and Mitigations_ v1.0 (March 2026) — [genai.owasp.org](https://genai.owasp.org)
-- **Compliance Mapping** — See [docs/compliance/DSGAI-MAPPING.md](docs/compliance/DSGAI-MAPPING.md) for 11 controls
+Help is welcome on: fitness-function examples for other stacks (Ruby, PHP, Java, C#), language-specific secret/PII patterns, session-context translations, real-world governance templates, and OWASP DSGAI Tier-3 controls (DSGAI05, DSGAI12, DSGAI13). See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/reference.md](docs/reference.md#development) for the local test commands.
 
 ---
 
 ## License
 
-[MIT](LICENSE) — Copyright (c) 2026 pitimon
+[MIT](LICENSE) — Copyright (c) 2026 pitimon.
+
+> กติกาที่ดีไม่ได้ทำให้คนเก่งขึ้น — แต่ทำให้ระบบไม่พังลง แม้ในวันที่คนพลาด.
+>
+> *Good rules don't make people smarter — they keep the system from breaking on the day someone slips.*

--- a/plugin/docs/reference.md
+++ b/plugin/docs/reference.md
@@ -1,0 +1,201 @@
+# Reference
+
+Full feature reference for `claude-governance`. The [README](../README.md) is the
+narrative overview; this is the lookup table.
+
+- [Hooks (always-on)](#hooks-always-on)
+- [Skills & agent (on-demand)](#skills--agent-on-demand)
+- [Governance checks (31)](#governance-checks-31)
+- [Fitness function stages](#fitness-function-stages)
+- [Language support](#language-support)
+- [Templates](#templates)
+- [Rules for `~/.claude/rules/`](#rules-for-clauderules)
+- [Platform support](#platform-support)
+- [Token budget](#token-budget)
+- [Project structure](#project-structure)
+- [Development](#development)
+
+Compliance mappings and the agent-harness coverage map live in their own docs:
+[DSGAI](compliance/DSGAI-MAPPING.md) · [EU AI Act](compliance/EU-AI-ACT-MAPPING.md) ·
+[ISO 42001](compliance/ISO-42001-MAPPING.md) · [NIST AI RMF](compliance/NIST-AI-RMF-MAPPING.md) ·
+[ETCLOVG coverage](architecture/etclovg-coverage.md).
+
+---
+
+## Hooks (always-on)
+
+Run automatically inside Claude Code. Codex does not run hooks.
+
+| Hook                   | Trigger              | What it does                                             |
+| ---------------------- | -------------------- | -------------------------------------------------------- |
+| **Governance context** | Session start        | Injects Three Loops + Consequence Override (~360 tokens) |
+| **Secret scanner**     | Every `Edit`/`Write` | 25 BLOCK patterns (secrets) + 3 WARN patterns (PII)      |
+
+## Skills & agent (on-demand)
+
+| Command               | When to use                   | Example                                       |
+| --------------------- | ----------------------------- | --------------------------------------------- |
+| `/governance-check`   | Before commit/push            | `/governance-check pre-commit`                |
+| `/create-adr`         | After an architecture decision| `/create-adr "Adopt PostgreSQL over MongoDB"` |
+| `/spec-driven-dev`    | Before feature implementation | `/spec-driven-dev` → writes `spec.md`         |
+| `/governance-setup`   | New-project initialization    | Creates `DOMAIN.md`, ADRs, rules              |
+| `/eu-ai-act-check`    | Before a high-risk AI release | EU AI Act Arts 9-15 readiness checklist       |
+| `/iso-42001-check`    | Before an AIMS audit / attest | ISO/IEC 42001:2023 AIMS 9-clause checklist    |
+| `governance-reviewer` | Before a PR (auto-triggered)  | Deep multi-file review with severity grading  |
+
+## Governance checks (31)
+
+| Category         | Count | Key checks                                                                                                        |
+| ---------------- | ----- | ----------------------------------------------------------------------------------------------------------------- |
+| **Pre-Commit**   | 14    | Secrets, input validation, file size, debug prints, AI model artifacts, unsafe deserialization, telemetry hygiene |
+| **Pre-PR**       | 5     | Conventional commits, DOMAIN.md sync, test coverage >= 80%                                                        |
+| **Architecture** | 12    | Service boundaries, auth coverage, plugin/MCP security, session isolation, consequence safeguards                 |
+
+## Fitness function stages
+
+Automated governance checks — "unit tests for architecture":
+
+| Stage                  | What gets checked                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pre-Implementation** | Spec exists, domain invariants identified, autonomy classified, irreversible ops flagged                                              |
+| **Pre-Commit**         | 14 checks: secrets, PII, validation, file size, functions, immutability, debug prints, AI artifacts, deserialization, deps, telemetry |
+| **Pre-PR**             | 5 checks: conventional commits, DOMAIN.md, breaking changes, test coverage, TODO context                                             |
+| **Architecture**       | 12 checks: service boundaries, auth, rate limiting, plugin/MCP, context minimization, session isolation, consequence safeguards       |
+
+## Language support
+
+Governance checks detect the project's language and apply stack-specific rules:
+
+| Check        | JS/TS                 | Python                               | Go               | Rust             |
+| ------------ | --------------------- | ------------------------------------ | ---------------- | ---------------- |
+| Debug prints | `console.log`         | `print()`                            | `fmt.Println`    | `println!`       |
+| Validation   | Zod, joi, yup         | pydantic, marshmallow                | go-validator     | serde, validator |
+| Dangerous    | `eval()`, `innerHTML` | `eval()`, `exec()`, `pickle.loads()` | `unsafe.Pointer` | `unsafe` blocks  |
+| Detection    | `package.json`        | `pyproject.toml`                     | `go.mod`         | `Cargo.toml`     |
+
+## Templates
+
+Ready-to-use templates shipped in `examples/`:
+
+| Template                         | Purpose                                              | Reference |
+| -------------------------------- | ---------------------------------------------------- | --------- |
+| `DATA-CLASSIFICATION.md.example` | 4-level data sensitivity with AI/LLM data flows      | DSGAI07   |
+| `mcp-security-checklist.md`      | Plugin/MCP vetting before installation               | DSGAI06   |
+| `shadow-ai-policy.md`            | Approved AI tools, data rules, exceptions            | DSGAI03   |
+| `ai-supply-chain-checklist.md`   | Model vetting, dependency pinning, safe alternatives | DSGAI04   |
+| `DOMAIN.md.example`              | Entity definitions, invariants, API contracts        | —         |
+| `adr-template.md`                | Architecture Decision Record with governance loop    | —         |
+| `project-claude-md.example`      | Example project `CLAUDE.md` with governance sections | —         |
+
+## Rules for `~/.claude/rules/`
+
+Optional — install with `bash ~/.claude/plugins/marketplaces/claude-governance/scripts/install-rules.sh`.
+
+| Rule              | Focus                                                                       |
+| ----------------- | --------------------------------------------------------------------------- |
+| `governance.md`   | Fitness functions: pre-implementation, pre-commit, pre-PR, architecture     |
+| `security.md`     | Secret management, agent/plugin security, PII, telemetry, session isolation |
+| `coding-style.md` | Immutability, file size limits, error handling                              |
+| `git-workflow.md` | Conventional commits, PR workflow, TDD                                      |
+| `testing.md`      | 80% coverage minimum, unit/integration/E2E                                  |
+
+## Platform support
+
+Skills, ADRs, and compliance docs are plain Markdown and work identically everywhere.
+The **hooks** (SessionStart context + PreToolUse secret scanner) are the only
+platform-sensitive surface:
+
+| Environment | Hook behaviour |
+| --- | --- |
+| macOS / Linux | `.sh` hooks run via bash (default) |
+| Windows **with** Git for Windows | `.sh` hooks run via Git Bash (Claude Code's default shell there) |
+| Windows **without** Git Bash | Claude Code falls back to the PowerShell shell tool; `.sh` hooks cannot run. PowerShell ports — `hooks/secret-scanner.ps1`, `hooks/session-start.ps1` — are provided and verified byte-for-byte equivalent to the bash hooks (parity gated on a `windows-latest` CI job). |
+| **Codex** (any OS) | Does not run hooks at all — skills are used as explicit checklists. |
+
+> **Native-Windows auto-dispatch is not yet wired into the default `hooks/hooks.json`.**
+> Claude Code exposes a single hook `command` per event with no OS switch, and selecting the
+> right script per-OS without breaking macOS/Linux users needs a mechanism that can only be
+> confirmed on a real Windows + Claude Code install (tracked in
+> [#58](https://github.com/pitimon/claude-governance/issues/58)). The `.ps1` hooks ship now
+> (proven on Windows PowerShell 5.1); a technical user can wire them manually via a personal
+> `settings.json` PreToolUse/SessionStart hook that runs
+> `powershell -NoProfile -ExecutionPolicy Bypass -File <path>` (the default Restricted policy
+> requires `-ExecutionPolicy Bypass`).
+
+**Requirement for the PowerShell path:** Windows 10 1809+ with Windows PowerShell 5.1 (included by default).
+
+## Token budget
+
+| Component            | Tokens   | When                        |
+| -------------------- | -------- | --------------------------- |
+| SessionStart hook    | ~360     | Every session               |
+| Secret scanner       | 0        | Shell script, no token cost |
+| Rules (if installed) | ~500-800 | Every session               |
+| Skills / agent       | 0        | Only when invoked           |
+
+**Total always-on cost:** ~360 tokens (without rules) / ~1,160 tokens (with rules).
+
+## Project structure
+
+```
+claude-governance/
+├── .claude-plugin/
+│   ├── plugin.json              # Plugin metadata, skills path, keywords
+│   └── marketplace.json         # Marketplace listing schema
+├── .codex-plugin/
+│   └── plugin.json              # Codex plugin metadata, shared skills path
+├── .agents/plugins/
+│   └── marketplace.json         # Codex marketplace listing
+├── plugin/                      # Codex marketplace child package mirror
+├── hooks/
+│   ├── hooks.json               # Hook registrations (SessionStart, PreToolUse)
+│   ├── session-start.sh         # Three Loops + Consequence Override injection
+│   ├── secret-scanner.sh        # 25 BLOCK + 3 WARN patterns, dual-loop
+│   ├── session-start.ps1        # PowerShell port (native Windows)
+│   └── secret-scanner.ps1       # PowerShell port (native Windows)
+├── skills/
+│   ├── governance-check/SKILL.md   # 31 checks across 3 categories
+│   ├── create-adr/SKILL.md         # ADR generator with governance loop
+│   ├── spec-driven-dev/SKILL.md    # Spec-first development workflow
+│   ├── governance-setup/SKILL.md   # 6-step project initialization
+│   ├── eu-ai-act-check/SKILL.md     # EU AI Act readiness checklist
+│   └── iso-42001-check/SKILL.md     # ISO/IEC 42001 AIMS readiness checklist
+├── agents/
+│   └── governance-reviewer.md   # Deep compliance review with severity grading
+├── examples/
+│   ├── rules/                   # 5 rules for ~/.claude/rules/
+│   └── *.example, *.md          # Templates (see Templates above)
+├── docs/
+│   ├── INTEGRATION.md           # Companion-plugin integration stub
+│   ├── notebooklm-workflow.md   # NotebookLM ↔ Claude Code grounded-corpus workflow
+│   ├── reference.md             # This file
+│   ├── adr/                     # 8 Architecture Decision Records
+│   ├── architecture/            # ETCLOVG 7-layer coverage map
+│   ├── compliance/              # DSGAI / EU AI Act / ISO 42001 / NIST AI RMF mappings
+│   └── research/                # Compliance research briefs
+├── scripts/
+│   ├── install-rules.sh         # Rules installer with backup
+│   └── bump-version.sh          # Version sync across Claude + Codex manifests
+├── tests/
+│   ├── validate-plugin.sh       # Structural integrity (100+ checks in CI)
+│   ├── test-secret-scanner.sh   # Pattern-by-pattern scanner tests
+│   └── test-release-qa.sh       # Release QA checks (runs in CI)
+└── .github/workflows/
+    └── validate.yml             # CI: structural + scanner + shellcheck + PowerShell parity
+```
+
+## Development
+
+```bash
+# Structural validation (100+ checks — CI signal)
+bash tests/validate-plugin.sh --skip-install-check
+
+# Scanner pattern tests
+bash tests/test-secret-scanner.sh
+
+# Release QA suite (8-Habit verified)
+bash tests/test-release-qa.sh
+
+# Bump version across all manifests
+bash scripts/bump-version.sh X.Y.Z
+```


### PR DESCRIPTION
## Summary
Restyle `README.md` after [genesis-governance-os](https://github.com/ElmatadorZ/genesis-governance-os) — "simple but clear": prose-first, narrative spine, restraint.

- **Property-led hero**, no badges — leads with *legible, safe, accountable* rather than feature counts.
- **Structural problem framing** — "the failures rarely come from bad code — they come from *ungoverned* code".
- **Two ways in** — guardrails-only vs project/team setup.
- **One-page overview**, Three Loops + Consequence, **numbered design principles**, standards-vs-examples, closing bilingual epigraph.
- README: **~500 → 138 lines**.

**No information lost.** The dense reference (hooks, skills, 31 checks, fitness stages, language support, templates, rules, platform support, token budget, project structure, dev commands) moves verbatim into new **`docs/reference.md`**, linked from the README. Compliance tables and ETCLOVG coverage keep their existing canonical docs.

## Test plan
- [x] `validate-plugin.sh` 150/0 — incl. skill discovery-surface check (all 6 skill names retained in README)
- [x] `test-release-qa.sh` 166/0
- [x] All 10 README internal links resolve to real files
- [x] Mirrors synced: `plugin/README.md` + `plugin/docs/reference.md`; `diff -qr docs plugin/docs` clean; fences balanced
- [ ] Maintainer eyeballs the rendered README + epigraph tone; decide whether to restore one usage example (secret-block demo) that the lean cut dropped