### PR TITLE
docs: restore worked usage examples in docs/reference.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Every task is classified on two axes: **who drives** (Three Loops) and **how bad
 
 **Go deeper:**
 
-- **[docs/reference.md](docs/reference.md)** — full feature reference: every hook, skill, check, template, rule, platform note, and the token budget.
+- **[docs/reference.md](docs/reference.md)** — worked usage examples plus the full feature reference: every hook, skill, check, template, rule, platform note, and the token budget.
 - **Compliance** — [DSGAI](docs/compliance/DSGAI-MAPPING.md) · [EU AI Act](docs/compliance/EU-AI-ACT-MAPPING.md) · [ISO 42001](docs/compliance/ISO-42001-MAPPING.md) · [NIST AI RMF](docs/compliance/NIST-AI-RMF-MAPPING.md).
 - **[Agent-harness coverage (ETCLOVG)](docs/architecture/etclovg-coverage.md)** — where this plugin is strong (`G`), partial (`C/L/V`), and deliberately out of scope (`E/T`). Adopter shorthand: use `claude-governance` for governance; pair with [`pitimon/devsecops-ai-team`](https://github.com/pitimon/devsecops-ai-team) for sandboxing (`E`) or MCP tooling (`T`).
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,6 +3,7 @@
 Full feature reference for `claude-governance`. The [README](../README.md) is the
 narrative overview; this is the lookup table.
 
+- [Usage examples](#usage-examples)
 - [Hooks (always-on)](#hooks-always-on)
 - [Skills & agent (on-demand)](#skills--agent-on-demand)
 - [Governance checks (31)](#governance-checks-31)
@@ -19,6 +20,76 @@ Compliance mappings and the agent-harness coverage map live in their own docs:
 [DSGAI](compliance/DSGAI-MAPPING.md) · [EU AI Act](compliance/EU-AI-ACT-MAPPING.md) ·
 [ISO 42001](compliance/ISO-42001-MAPPING.md) · [NIST AI RMF](compliance/NIST-AI-RMF-MAPPING.md) ·
 [ETCLOVG coverage](architecture/etclovg-coverage.md).
+
+---
+
+## Usage examples
+
+### Catch a leaked API key before it enters git
+
+The secret scanner runs on every `Edit`/`Write` and blocks the write before it reaches disk:
+
+```
+You: Write the config file with the API key
+
+Claude writes: api_key = "sk-ant-api03-xxxxx"
+
+  Governance: Blocked — Anthropic API key detected.
+  Use environment variables instead:
+    JS/TS:  const value = process.env.YOUR_SECRET
+    Python: value = os.environ['YOUR_SECRET']
+    Go:     value := os.Getenv("YOUR_SECRET")
+```
+
+### Run pre-commit governance checks
+
+```
+You: /governance-check pre-commit
+
+  ## Governance Check: pre-commit
+
+  ### Passed
+  - [x] No hardcoded secrets found
+  - [x] Input validation present (Zod schema)
+  - [x] File sizes within limits
+  - [x] No debug prints in production
+
+  ### Failed
+  - [ ] FAIL: `src/ml/loader.py:12` — torch.load() without weights_only=True [DSGAI04]
+  - [ ] FAIL: `src/api/handler.ts` — 847 lines (max 800)
+
+  Passed: 8/10 | Failed: 2
+```
+
+### Classify a task with Three Loops + Consequence
+
+```
+You: Format the deployment config and push to production
+
+Claude: This task is Out-of-Loop (formatting) BUT involves irreversible
+        consequence (production deploy). Per ADR-002 Consequence Override:
+        Irreversible → always In-the-Loop.
+
+        I'll format the file, but you should review and deploy manually.
+```
+
+### Initialize governance in a new project
+
+```
+You: /governance-setup
+
+  Step 1: Creating DOMAIN.md...
+  Step 2: Setting up docs/adr/
+  Step 3: Data Classification (Optional)
+  Step 3.5: Shadow AI Policy (Optional)
+  Step 4: Install Rules
+
+  Governance initialized:
+  - DOMAIN.md — edit to define your entities
+  - docs/adr/ADR-001 — governance adoption record
+  - DATA-CLASSIFICATION.md — data sensitivity levels
+  - shadow-ai-policy.md — approved AI tools
+```
 
 ---
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -105,7 +105,7 @@ Every task is classified on two axes: **who drives** (Three Loops) and **how bad
 
 **Go deeper:**
 
-- **[docs/reference.md](docs/reference.md)** — full feature reference: every hook, skill, check, template, rule, platform note, and the token budget.
+- **[docs/reference.md](docs/reference.md)** — worked usage examples plus the full feature reference: every hook, skill, check, template, rule, platform note, and the token budget.
 - **Compliance** — [DSGAI](docs/compliance/DSGAI-MAPPING.md) · [EU AI Act](docs/compliance/EU-AI-ACT-MAPPING.md) · [ISO 42001](docs/compliance/ISO-42001-MAPPING.md) · [NIST AI RMF](docs/compliance/NIST-AI-RMF-MAPPING.md).
 - **[Agent-harness coverage (ETCLOVG)](docs/architecture/etclovg-coverage.md)** — where this plugin is strong (`G`), partial (`C/L/V`), and deliberately out of scope (`E/T`). Adopter shorthand: use `claude-governance` for governance; pair with [`pitimon/devsecops-ai-team`](https://github.com/pitimon/devsecops-ai-team) for sandboxing (`E`) or MCP tooling (`T`).
 

--- a/plugin/docs/reference.md
+++ b/plugin/docs/reference.md
@@ -3,6 +3,7 @@
 Full feature reference for `claude-governance`. The [README](../README.md) is the
 narrative overview; this is the lookup table.
 
+- [Usage examples](#usage-examples)
 - [Hooks (always-on)](#hooks-always-on)
 - [Skills & agent (on-demand)](#skills--agent-on-demand)
 - [Governance checks (31)](#governance-checks-31)
@@ -19,6 +20,76 @@ Compliance mappings and the agent-harness coverage map live in their own docs:
 [DSGAI](compliance/DSGAI-MAPPING.md) · [EU AI Act](compliance/EU-AI-ACT-MAPPING.md) ·
 [ISO 42001](compliance/ISO-42001-MAPPING.md) · [NIST AI RMF](compliance/NIST-AI-RMF-MAPPING.md) ·
 [ETCLOVG coverage](architecture/etclovg-coverage.md).
+
+---
+
+## Usage examples
+
+### Catch a leaked API key before it enters git
+
+The secret scanner runs on every `Edit`/`Write` and blocks the write before it reaches disk:
+
+```
+You: Write the config file with the API key
+
+Claude writes: api_key = "sk-ant-api03-xxxxx"
+
+  Governance: Blocked — Anthropic API key detected.
+  Use environment variables instead:
+    JS/TS:  const value = process.env.YOUR_SECRET
+    Python: value = os.environ['YOUR_SECRET']
+    Go:     value := os.Getenv("YOUR_SECRET")
+```
+
+### Run pre-commit governance checks
+
+```
+You: /governance-check pre-commit
+
+  ## Governance Check: pre-commit
+
+  ### Passed
+  - [x] No hardcoded secrets found
+  - [x] Input validation present (Zod schema)
+  - [x] File sizes within limits
+  - [x] No debug prints in production
+
+  ### Failed
+  - [ ] FAIL: `src/ml/loader.py:12` — torch.load() without weights_only=True [DSGAI04]
+  - [ ] FAIL: `src/api/handler.ts` — 847 lines (max 800)
+
+  Passed: 8/10 | Failed: 2
+```
+
+### Classify a task with Three Loops + Consequence
+
+```
+You: Format the deployment config and push to production
+
+Claude: This task is Out-of-Loop (formatting) BUT involves irreversible
+        consequence (production deploy). Per ADR-002 Consequence Override:
+        Irreversible → always In-the-Loop.
+
+        I'll format the file, but you should review and deploy manually.
+```
+
+### Initialize governance in a new project
+
+```
+You: /governance-setup
+
+  Step 1: Creating DOMAIN.md...
+  Step 2: Setting up docs/adr/
+  Step 3: Data Classification (Optional)
+  Step 3.5: Shadow AI Policy (Optional)
+  Step 4: Install Rules
+
+  Governance initialized:
+  - DOMAIN.md — edit to define your entities
+  - docs/adr/ADR-001 — governance adoption record
+  - DATA-CLASSIFICATION.md — data sensitivity levels
+  - shadow-ai-policy.md — approved AI tools
+```
 
 ---
 


### PR DESCRIPTION
## Summary
Restore the concrete demos that the lean README rewrite (#62) dropped — placed in `docs/reference.md`, not the README, so the README stays lean.

- New **Usage examples** section: secret-block demo, `/governance-check` output, Three Loops + Consequence classification, `/governance-setup` walkthrough.
- README's reference link now advertises "worked usage examples".

The Anthropic-key string is a `xxxxx` **placeholder** demonstrating the scanner (historically shipped in README, CI-green), not a live credential.

## Test plan
- [x] `validate-plugin.sh` + `test-release-qa.sh` pass locally
- [x] Mirrors synced (`plugin/README.md`, `plugin/docs/reference.md`); `diff -qr docs plugin/docs` clean; fences balanced (12)
- [x] Reference TOC updated; README pointer added